### PR TITLE
Implement data propagator with indicators caching

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,0 +1,1 @@
+threshold: medium

--- a/app/dependencies/redis.py
+++ b/app/dependencies/redis.py
@@ -1,0 +1,8 @@
+from redis.asyncio import Redis
+import os
+
+redis_client = Redis.from_url(
+    os.getenv("REDIS_URL", "redis://indicators-redis:6379"),
+    encoding="utf-8",
+    decode_responses=True
+)

--- a/app/main.py
+++ b/app/main.py
@@ -3,29 +3,64 @@ from routes import router as api_router
 from dependencies.rabbitmq import RabbitMQConnection
 from services.data_ingestor import start_consuming
 import asyncio
+import logging
 import os
 from dotenv import load_dotenv
 
 load_dotenv()
 
+logger = logging.getLogger(__name__)
+
 app = FastAPI()
 
 app.include_router(api_router)
 
-# Initialize RabbitMQ Connection
-rabbitmq_url = os.getenv("RABBITMQ_URL", "amqp://guest:guest@localhost/")
-rabbitmq = RabbitMQConnection(rabbitmq_url, queue_name="resource_data")
+# Store the consumer task and connection
+consumer_task = None
+rabbitmq_connection = None
+
+# RabbitMQ Configuration
+RABBITMQ_URL = os.getenv("RABBITMQ_URL", "amqp://guest:guest@rabbitmq/")
+QUEUE_NAME = "resource_data"
 
 
 @app.on_event("startup")
 async def startup_event():
-    # Start the consumer in the background
-    asyncio.create_task(start_consuming(rabbitmq))
+    """Start the RabbitMQ consumer when the application starts"""
+    global consumer_task, rabbitmq_connection
+    try:
+        # Create and connect RabbitMQ
+        rabbitmq_connection = RabbitMQConnection(
+            url=RABBITMQ_URL,
+            queue_name=QUEUE_NAME
+        )
+        await rabbitmq_connection.connect()
+        logger.info("Connected to RabbitMQ")
+
+        # Start consumer in background task
+        consumer_task = asyncio.create_task(
+            start_consuming(rabbitmq_connection))
+        logger.info("Started RabbitMQ consumer")
+    except Exception as e:
+        logger.error(f"Failed to start RabbitMQ consumer: {e}")
+        raise
 
 
 @app.on_event("shutdown")
 async def shutdown_event():
-    await rabbitmq.close()
+    """Cleanup when the application shuts down"""
+    global consumer_task, rabbitmq_connection
+    if consumer_task:
+        consumer_task.cancel()
+        try:
+            await consumer_task
+        except asyncio.CancelledError:
+            pass
+        logger.info("Stopped RabbitMQ consumer")
+
+    if rabbitmq_connection:
+        await rabbitmq_connection.close()
+        logger.info("Closed RabbitMQ connection")
 
 # Command to run the application:
 # uvicorn app.main:app --host 0.0.0.0 --port 8000

--- a/app/routes/data_routes.py
+++ b/app/routes/data_routes.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter, HTTPException, Query
-from typing import List, Optional, Dict
+from typing import List, Optional
 from datetime import datetime
 from schemas.data_segment import DataPoint
 from schemas.common import PyObjectId
 from bson.errors import InvalidId
+from services.data_propagator import get_sorted_data_points, get_data_points_by_date
 
 router = APIRouter()
 
@@ -24,8 +25,13 @@ async def get_indicator_data(
     except (InvalidId, ValueError):
         raise HTTPException(status_code=400, detail=INVALID_INDICATOR_ID)
 
-    # Logic will be implemented in service layer
-    raise HTTPException(status_code=501, detail="Not implemented")
+    points = await get_data_points_by_date(
+        indicator_id,
+        start_date=start_date,
+        end_date=end_date,
+        limit=limit
+    )
+    return points
 
 
 @router.get("/{indicator_id}/data", response_model=List[DataPoint])
@@ -41,5 +47,10 @@ async def get_paginated_data(
     except (InvalidId, ValueError):
         raise HTTPException(status_code=400, detail=INVALID_INDICATOR_ID)
 
-    # Logic will be implemented in service layer
-    raise HTTPException(status_code=501, detail="Not implemented")
+    points = await get_sorted_data_points(
+        indicator_id,
+        skip=skip,
+        limit=limit,
+        sort=sort
+    )
+    return points

--- a/app/routes/indicator_routes.py
+++ b/app/routes/indicator_routes.py
@@ -15,6 +15,9 @@ from services.indicator_service import (
 )
 from schemas.indicator import IndicatorCreate, IndicatorUpdate, IndicatorPatch, Indicator, IndicatorDelete, SimpleIndicator
 from schemas.resource import ResourceCreate
+import logging
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -163,7 +166,7 @@ async def get_resources_route(indicator_id: str):
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@router.delete("/{indicator_id}/resources/{resource_id}", response_model=Indicator)
+@router.delete("/{indicator_id}/resources/{resource_id}", response_model=SimpleIndicator)
 async def remove_resource_route(indicator_id: str, resource_id: str):
     """Remove association of a resource from an indicator"""
     try:

--- a/app/services/data_ingestor.py
+++ b/app/services/data_ingestor.py
@@ -3,19 +3,28 @@ import aio_pika
 import logging
 from dependencies.database import db
 from schemas.data_segment import DataSegment, TimePoint
-from services.indicator_service import get_indicator_by_id
+from services.indicator_service import get_indicator_by_id, get_indicator_by_resource
 from dependencies.rabbitmq import RabbitMQConnection
+from services.data_propagator import get_cache_key
+from dependencies.redis import redis_client
+from bson.errors import InvalidId
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
 async def store_data_segment(segment: DataSegment):
-    """Store data segment in MongoDB"""
+    """Store data segment in MongoDB and clear cache"""
     try:
+        # Store in MongoDB
         await db.data_segments.insert_one(segment.model_dump())
         logger.info(
             f"Stored data segment for indicator {segment.indicator_id}")
+
+        # Clear cache for this indicator
+        cache_key = get_cache_key(str(segment.indicator_id))
+        await redis_client.delete(cache_key)
+
     except Exception as e:
         logger.error(f"Failed to store data segment: {e}")
         raise
@@ -23,40 +32,72 @@ async def store_data_segment(segment: DataSegment):
 
 async def process_message(message: aio_pika.IncomingMessage):
     """Process incoming messages from RabbitMQ"""
-    async with message.process():
+    try:
         # Parse message
         data = json.loads(message.body.decode())
+        logger.info(f"Processing message: {data}")
+
         resource_id = data.get('resource')
         points = data.get('data', [])
 
         if not resource_id or not points:
-            logger.warning("Invalid message format")
+            logger.warning("Invalid message format - discarding message")
+            await message.ack()  # Acknowledge and discard
             return
 
-        # Find indicator by resource
-        indicator = await get_indicator_by_id(resource_id)
-        if not indicator:
-            raise ValueError(
-                f"No indicator found for resource {resource_id}")
+        try:
+            # Find indicator by resource
+            indicator = await get_indicator_by_resource(resource_id)
+            if not indicator:
+                logger.warning(
+                    f"No indicator found for resource {resource_id} - discarding message")
+                await message.ack()  # Acknowledge and discard
+                return
 
-        # Convert points to TimePoint objects
-        data_points = [TimePoint(x=p['x'], y=p['y']) for p in points]
+            # Convert points to TimePoint objects
+            data_points = [TimePoint(x=p['x'], y=p['y']) for p in points]
 
-        # Create and store data segment
-        segment = DataSegment(
-            indicator_id=indicator["id"],
-            points=data_points
-        )
-        await store_data_segment(segment)
+            # Create and store data segment
+            segment = DataSegment(
+                indicator_id=indicator["id"],
+                points=data_points
+            )
+            await store_data_segment(segment)
 
-        logger.info(
-            f"Successfully processed data for resource {resource_id}")
+            logger.info(
+                f"Successfully processed data for resource {resource_id}")
+            await message.ack()
+
+        except InvalidId as e:
+            logger.error(f"Invalid ObjectId format - discarding message: {e}")
+            await message.ack()  # Acknowledge and discard invalid IDs
+            return
+
+    except json.JSONDecodeError as e:
+        logger.error(f"Invalid JSON format - discarding message: {e}")
+        await message.ack()  # Acknowledge and discard invalid JSON
+
+    except Exception as e:
+        logger.error(f"Error processing message: {e}")
+        # Only requeue for unexpected errors
+        await message.reject(requeue=True)
 
 
 async def start_consuming(connection: RabbitMQConnection):
     """Start consuming messages from RabbitMQ"""
-    queue = await connection.get_queue()
+    try:
+        channel = await connection.connection.channel()
+        queue = await channel.declare_queue(
+            "resource_data",
+            durable=True
+        )
 
-    async with queue.iterator() as queue_iter:
-        async for message in queue_iter:
-            await process_message(message)
+        logger.info(f"Started consuming from queue: {queue.name}")
+
+        async with queue.iterator() as queue_iter:
+            async for message in queue_iter:
+                await process_message(message)
+
+    except Exception as e:
+        logger.error(f"Error in consumer: {e}")
+        raise

--- a/app/services/data_propagator.py
+++ b/app/services/data_propagator.py
@@ -1,0 +1,122 @@
+from typing import List, Union, Dict, Tuple
+from datetime import datetime, timedelta
+import json
+from schemas.data_segment import DataPoint, TimePoint
+from dependencies.database import db
+from dependencies.redis import redis_client
+from bson.objectid import ObjectId
+import logging
+
+logger = logging.getLogger(__name__)
+
+CACHE_KEY_PREFIX = "indicator_data:"
+CACHE_TTL = timedelta(hours=1)  # Cache expiration time
+
+
+def get_cache_key(indicator_id: str) -> str:
+    return f"{CACHE_KEY_PREFIX}{indicator_id}"
+
+
+async def update_cached_data(indicator_id: str) -> List[DataPoint]:
+    """Process and cache indicator data"""
+    segments = await db.data_segments.find(
+        {"indicator_id": ObjectId(indicator_id)}
+    ).to_list(None)
+
+    logger.info(f"Updating cached data for indicator {indicator_id}")
+    logger.info(f"Found {len(segments)} segments")
+    logger.info(f"Segments: {segments}")
+
+    time_series_points: Dict[datetime, Tuple[float, datetime]] = {}
+    numeric_points = []
+
+    for segment in segments:
+        segment_timestamp = segment.get("timestamp")
+        if not segment_timestamp:
+            continue
+
+        for point in segment["points"]:
+            if isinstance(point["x"], (str, datetime)):
+                x_value = datetime.fromisoformat(point["x"].replace(
+                    'Z', '+00:00')) if isinstance(point["x"], str) else point["x"]
+
+                current = time_series_points.get(x_value)
+                if not current or segment_timestamp > current[1]:
+                    time_series_points[x_value] = (
+                        point["y"], segment_timestamp)
+            else:
+                numeric_points.append(
+                    {"x": float(point["x"]), "y": float(point["y"])})
+
+    time_points = [{"x": x.isoformat(), "y": y}
+                   for x, (y, _) in time_series_points.items()]
+
+    # Sort all points in ascending order
+    sorted_points = sorted(
+        time_points + numeric_points,
+        key=lambda p: p["x"]
+    )
+
+    # Cache the processed data
+    cache_key = get_cache_key(indicator_id)
+    await redis_client.set(
+        cache_key,
+        json.dumps(sorted_points),
+        ex=int(CACHE_TTL.total_seconds())
+    )
+
+    return sorted_points
+
+
+async def get_sorted_data_points(
+    indicator_id: str,
+    skip: int = 0,
+    limit: int = 50,
+    sort: str = "asc"
+) -> List[DataPoint]:
+    """Get sorted data points for an indicator using cache"""
+    cache_key = get_cache_key(indicator_id)
+    cached_data = await redis_client.get(cache_key)
+
+    if cached_data:
+        points = json.loads(cached_data)
+    else:
+        points = await update_cached_data(indicator_id)
+
+    # Apply sort and pagination
+    if sort == "desc":
+        points = list(reversed(points))
+
+    return points[skip:skip + limit]
+
+
+async def get_data_points_by_date(
+    indicator_id: str,
+    start_date: datetime = None,
+    end_date: datetime = None,
+    limit: int = 100
+) -> List[DataPoint]:
+    """Get data points filtered by date range using cache"""
+    cache_key = get_cache_key(indicator_id)
+    cached_data = await redis_client.get(cache_key)
+
+    if cached_data:
+        points = json.loads(cached_data)
+    else:
+        points = await update_cached_data(indicator_id)
+
+    # Filter by date range
+    if start_date or end_date:
+        filtered_points = []
+        for point in points:
+            if isinstance(point["x"], str):
+                point_date = datetime.fromisoformat(
+                    point["x"].replace('Z', '+00:00'))
+                if start_date and point_date < start_date:
+                    continue
+                if end_date and point_date > end_date:
+                    continue
+            filtered_points.append(point)
+        points = filtered_points
+
+    return points[:limit]

--- a/data-producer-example/data_producer/Dockerfile
+++ b/data-producer-example/data_producer/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY tests/data_producer/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY tests/data_producer/data_producer.py .
+
+CMD ["python", "data_producer.py"] 

--- a/data-producer-example/data_producer/data_producer.py
+++ b/data-producer-example/data_producer/data_producer.py
@@ -1,0 +1,146 @@
+import asyncio
+import aio_pika
+import json
+from datetime import datetime, timedelta
+import random
+import os
+import aiohttp
+from typing import List, Dict
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+RABBITMQ_URL = os.getenv("RABBITMQ_URL", "amqp://guest:guest@rabbitmq/")
+API_URL = os.getenv("API_URL", "http://indicator-service:8080")
+QUEUE_NAME = "resource_data"
+
+
+async def fetch_indicators() -> List[Dict]:
+    """Fetch all indicators from the API"""
+    logger.info(f"Fetching indicators from {API_URL}/indicators")
+    async with aiohttp.ClientSession() as session:
+        try:
+            async with session.get(f"{API_URL}/indicators") as response:
+                if response.status == 200:
+                    data = await response.json()
+                    logger.info(f"Found {len(data)} indicators")
+                    return data
+                else:
+                    text = await response.text()
+                    logger.error(
+                        f"API returned status {response.status}: {text}")
+                    raise Exception(
+                        f"Failed to fetch indicators: {response.status}")
+        except aiohttp.ClientError as e:
+            logger.error(f"Connection error: {e}")
+            raise
+
+
+async def fetch_indicator_resources(indicator_id: str) -> List[str]:
+    """Fetch resources for a specific indicator"""
+    logger.info(f"Fetching resources for indicator {indicator_id}")
+    async with aiohttp.ClientSession() as session:
+        try:
+            async with session.get(f"{API_URL}/indicators/{indicator_id}") as response:
+                if response.status == 200:
+                    data = await response.json()
+                    resources = data.get("resources", [])
+                    logger.info(f"Found {len(resources)} resources")
+                    return resources
+                else:
+                    text = await response.text()
+                    logger.error(
+                        f"API returned status {response.status}: {text}")
+                    raise Exception(
+                        f"Failed to fetch resources: {response.status}")
+        except aiohttp.ClientError as e:
+            logger.error(f"Connection error: {e}")
+            raise
+
+
+async def generate_sample_data(resource_id: str, num_points: int = 10) -> dict:
+    """Generate sample time series data"""
+    base_time = datetime.now()
+    points = []
+
+    for i in range(num_points):
+        point_time = base_time + timedelta(hours=i)
+        points.append({
+            "x": point_time.isoformat(),
+            "y": random.uniform(0, 100)
+        })
+
+    return {
+        "resource": resource_id,
+        "data": points
+    }
+
+
+async def send_data():
+    # Establish connection with retries
+    for _ in range(5):  # 5 attempts
+        try:
+            logger.info(f"Connecting to RabbitMQ at {RABBITMQ_URL}")
+            connection = await aio_pika.connect_robust(RABBITMQ_URL)
+            break
+        except Exception as e:
+            logger.error(f"Failed to connect, retrying... Error: {e}")
+            await asyncio.sleep(5)
+    else:
+        raise Exception("Failed to connect to RabbitMQ after 5 attempts")
+
+    logger.info("Successfully connected to RabbitMQ")
+
+    async with connection:
+        channel = await connection.channel()
+        queue = await channel.declare_queue(
+            QUEUE_NAME,
+            durable=True
+        )
+
+        while True:  # Continuous loop
+            try:
+                # Fetch all indicators
+                indicators = await fetch_indicators()
+
+                for indicator in indicators:
+                    # Fetch resources for each indicator
+                    resources = await fetch_indicator_resources(indicator["id"])
+
+                    if not resources:
+                        logger.warning(
+                            f"No resources for indicator {indicator['id']}")
+                        continue
+
+                    logger.info(
+                        f"Generating data for indicator {indicator['id']} with {len(resources)} resources")
+
+                    # Generate and send data for each resource
+                    for resource_id in resources:
+                        data = await generate_sample_data(resource_id, num_points=24)
+                        message = aio_pika.Message(
+                            body=json.dumps(data).encode(),
+                            delivery_mode=aio_pika.DeliveryMode.PERSISTENT
+                        )
+
+                        await channel.default_exchange.publish(
+                            message,
+                            routing_key=queue.name
+                        )
+
+                        logger.info(
+                            f"Sent data for indicator {indicator['id']}, resource: {resource_id}")
+                        await asyncio.sleep(1)
+
+                logger.info("Completed data generation cycle")
+                await asyncio.sleep(6)
+
+            except Exception as e:
+                logger.error(f"Error in data generation cycle: {e}")
+                await asyncio.sleep(2)
+
+
+if __name__ == "__main__":
+    asyncio.run(send_data())

--- a/data-producer-example/data_producer/requirements.txt
+++ b/data-producer-example/data_producer/requirements.txt
@@ -1,0 +1,2 @@
+aio-pika==9.3.0
+aiohttp==3.9.3 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   indicator-service:
     build: .
     container_name: indicator-service
+    ports:
+      - "8080:8080"
     restart: on-failure
     environment:
       - REDIS_HOST=indicators-redis
@@ -15,6 +17,8 @@ services:
         condition: service_healthy
       indicators-redis:
         condition: service_started
+    networks:
+      - indicator-network
     develop:
       watch:
         - action: sync
@@ -25,18 +29,41 @@ services:
         - action: rebuild
           path: requirements.txt
 
+  data-producer:
+    build:
+      context: .
+      dockerfile: data-producer-example/data_producer/Dockerfile
+    container_name: indicator-data-producer
+    profiles: ["development"]
+    environment:
+      - RABBITMQ_URL=amqp://guest:guest@rabbitmq/
+      - API_URL=http://indicator-service:8080
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      indicator-service:
+        condition: service_started
+    networks:
+      - indicator-network
+    restart: on-failure
+
   indicators-redis:
     image: "redis:alpine"
     container_name: indicators-redis
+    networks:
+      - indicator-network
     restart: on-failure
 
   indicators-mongo:
     image: "mongo:latest"
     container_name: indicators-mongo
+    profiles: ["development"]
     environment:
       MONGO_INITDB_DATABASE: indicators
     volumes:
       - indicators_db:/data/db
+    networks:
+      - indicator-network
     healthcheck:
       test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
       interval: 6s
@@ -54,6 +81,8 @@ services:
     environment:
       - RABBITMQ_DEFAULT_USER=guest
       - RABBITMQ_DEFAULT_PASS=guest
+    networks:
+      - indicator-network
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "check_port_connectivity"]
       interval: 6s
@@ -61,6 +90,10 @@ services:
       retries: 5
       start_period: 6s
     restart: on-failure
+
+networks:
+  indicator-network:
+    name: indicator-network
 
 volumes:
   indicators_db:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
-pydantic
-motor
-fastapi
-uvicorn
-python-dotenv
-aio-pika
+pydantic==2.4.2
+motor==3.3.1
+pymongo==4.6.1
+fastapi==0.115.12
+uvicorn==0.34.1
+python-dotenv==1.0.0
+aio-pika==9.3.0
+redis==5.0.1


### PR DESCRIPTION
This pull requests adds the logic to merge data segments and expose the result as a single time serie for each indicator. To avoid redundant  computations, the processed results are stored in a Redis instance, that is cleaned only when data changed.

This also includes a producer that simulates messages sent by resource service.

Notes: a solution to handle indicators removal is needed