### PR TITLE
admin can now insert indicators and they appear

### DIFF
--- a/app/routes/indicator_routes.py
+++ b/app/routes/indicator_routes.py
@@ -61,6 +61,7 @@ async def get_indicator_route(indicator_id: str):
 async def get_indicators_by_domain_route(
     domain_id: str, skip: int = Query(0, ge=0), limit: int = Query(10, ge=1, le=50)
 ):
+    logger.info(f"ROUTE: get_indicators_by_domain_route called with domain_id={domain_id}")
     try:
         PyObjectId(domain_id)
     except (InvalidId, ValueError):


### PR DESCRIPTION


### Logging improvements:

* [`app/routes/indicator_routes.py`](diffhunk://#diff-09e14708c72b8cc909139d041bd598716dbd9dfbdd80f1a4afdd882d253b85b3R64): Added a log statement to the `get_indicators_by_domain_route` function to trace when the route is called and with which parameters.
* [`app/services/indicator_service.py`](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cL21-R26): Added a debug log in the `create_indicator` function to log the type and value of the domain ID being inserted into the database.

### Domain ID handling:

* [`app/services/indicator_service.py`](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR94-R104): Updated the `get_indicators_by_domain` and `get_indicators_by_subdomain` functions to filter indicators by domain ID as a string instead of an `ObjectId`, reflecting the current storage format.
* [`app/services/indicator_service.py`](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cL21-R26): Modified the `create_indicator` function to store the domain ID as an `ObjectId` when creating a new indicator, ensuring consistency with the expected format during insertion.