### PR TITLE
protect endpoints

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -36,6 +36,25 @@ def _get_signing_key(jwks, token):
     raise JWTError("No matching key found")
 
 
+async def require_auth(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+):
+    token = credentials.credentials
+    try:
+        jwks = await _get_jwks()
+        key = _get_signing_key(jwks, token)
+        payload = jwt.decode(
+            token, key, algorithms=ALGORITHMS, options={"verify_aud": False}
+        )
+    except JWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return payload
+
+
 async def require_admin(
     credentials: HTTPAuthorizationCredentials = Depends(security),
 ):

--- a/app/routes/indicator_routes.py
+++ b/app/routes/indicator_routes.py
@@ -1,6 +1,6 @@
 from typing import List
 from fastapi import APIRouter, HTTPException, Query, Response, BackgroundTasks, Depends
-from auth import require_admin
+from auth import require_admin, require_auth
 from bson.errors import InvalidId
 from schemas.common import PyObjectId
 from services.indicator_service import (
@@ -336,7 +336,7 @@ async def get_resources_route(indicator_id: str):
 
 @router.post("/{indicator_id}/export/image", response_class=Response)
 async def export_indicator_image(
-    indicator_id: str, request: ChartExportRequest, background_tasks: BackgroundTasks
+    indicator_id: str, request: ChartExportRequest, background_tasks: BackgroundTasks, _=Depends(require_auth)
 ):
     """
     Generate and return a PNG image of the indicator chart based on the provided configuration.


### PR DESCRIPTION
This pull request introduces authentication requirements for exporting indicator images, ensuring that only authenticated users can perform this operation. The main changes involve importing and using a new `require_auth` dependency and implementing the authentication logic.

**Authentication enhancements:**

* Added a new `require_auth` function in `app/auth.py` to validate JWT tokens for incoming requests, raising an HTTP 401 error if authentication fails.
* Updated the image export endpoint in `app/routes/indicator_routes.py` to require authentication by adding `Depends(require_auth)` as a dependency.
* Modified imports in `app/routes/indicator_routes.py` to include the new `require_auth` dependency.