### PR TITLE
fix chart exports

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -36,41 +36,35 @@ def _get_signing_key(jwks, token):
     raise JWTError("No matching key found")
 
 
-async def require_auth(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
-):
+async def _decode_token(credentials: HTTPAuthorizationCredentials) -> dict:
     token = credentials.credentials
     try:
         jwks = await _get_jwks()
         key = _get_signing_key(jwks, token)
-        payload = jwt.decode(
-            token, key, algorithms=ALGORITHMS, options={"verify_aud": False}
-        )
+        return jwt.decode(token, key, algorithms=ALGORITHMS, options={"verify_aud": False})
     except JWTError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired token",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    return payload
+    except httpx.HTTPError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service unavailable",
+        )
+
+
+async def require_auth(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+):
+    return await _decode_token(credentials)
 
 
 async def require_admin(
     credentials: HTTPAuthorizationCredentials = Depends(security),
 ):
-    token = credentials.credentials
-    try:
-        jwks = await _get_jwks()
-        key = _get_signing_key(jwks, token)
-        payload = jwt.decode(
-            token, key, algorithms=ALGORITHMS, options={"verify_aud": False}
-        )
-    except JWTError:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid or expired token",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
+    payload = await _decode_token(credentials)
     roles = payload.get("realm_access", {}).get("roles", [])
     if "admin" not in roles:
         raise HTTPException(

--- a/app/routes/indicator_routes.py
+++ b/app/routes/indicator_routes.py
@@ -276,11 +276,41 @@ async def patch_indicator_route(indicator_id: str, indicator: IndicatorPatch, _=
     except (InvalidId, ValueError):
         raise HTTPException(status_code=400, detail=INVALID_INDICATOR_ID)
     try:
-        await update_indicator(indicator_id, indicator.dict(exclude_unset=True))
+        patch_data = indicator.dict(exclude_unset=True)
+
+        # The IndicatorPatch model only validates chart_types vs
+        # default_chart_type when both are present in the payload. For a PATCH
+        # that touches just one of them, re-validate the *merged* document so
+        # we never persist a default that isn't in the stored chart_types.
+        if "chart_types" in patch_data or "default_chart_type" in patch_data:
+            existing = await get_indicator_by_id(indicator_id)
+            if not existing:
+                raise HTTPException(status_code=404, detail=NOT_FOUND_MESSAGE)
+            existing_dict = existing.model_dump() if hasattr(existing, "model_dump") else dict(existing)
+            merged_chart_types = patch_data.get(
+                "chart_types", existing_dict.get("chart_types") or []
+            )
+            merged_default = patch_data.get(
+                "default_chart_type", existing_dict.get("default_chart_type")
+            )
+            if not merged_chart_types:
+                raise HTTPException(
+                    status_code=400,
+                    detail="chart_types must contain at least one chart type",
+                )
+            if merged_default is not None and merged_default not in merged_chart_types:
+                raise HTTPException(
+                    status_code=400,
+                    detail="default_chart_type must be one of the values in chart_types",
+                )
+
+        await update_indicator(indicator_id, patch_data)
         updated_indicator = await get_indicator_by_id(indicator_id)
         if not updated_indicator:
             raise HTTPException(status_code=404, detail=NOT_FOUND_MESSAGE)
         return updated_indicator
+    except HTTPException:
+        raise
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/app/schemas/chart_export.py
+++ b/app/schemas/chart_export.py
@@ -10,6 +10,20 @@ class ChartType(str, Enum):
     bar = "bar"
     column = "column"
     scatter = "scatter"
+    # Aggregate visualizations: derived from {x,y} time-series data
+    pie = "pie"
+    donut = "donut"
+    treemap = "treemap"
+    heatmap = "heatmap"
+    # Shape-specific types: require specially-structured series data
+    # (box plot: [min,q1,median,q3,max]; candlestick: [open,high,low,close];
+    # range bar / range area: [low, high]). When the underlying data does
+    # not match the required shape, the renderer falls back to an empty
+    # chart with an informational message.
+    boxPlot = "boxPlot"
+    candlestick = "candlestick"
+    rangeBar = "rangeBar"
+    rangeArea = "rangeArea"
 
 
 class XAxisType(str, Enum):

--- a/app/schemas/chart_export.py
+++ b/app/schemas/chart_export.py
@@ -19,7 +19,7 @@ class ChartType(str, Enum):
     # (box plot: [min,q1,median,q3,max]; candlestick: [open,high,low,close];
     # range bar / range area: [low, high]). When the underlying data does
     # not match the required shape, the renderer falls back to an empty
-    # chart with an informational message.
+    # chart carrying the message "Chart type not supported for this data".
     boxPlot = "boxPlot"
     candlestick = "candlestick"
     rangeBar = "rangeBar"

--- a/app/schemas/indicator.py
+++ b/app/schemas/indicator.py
@@ -1,7 +1,17 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
 from typing import Optional, List
 from schemas.domain import Domain
 from schemas.common import PyObjectId
+from schemas.chart_export import ChartType
+
+
+DEFAULT_CHART_TYPES: List[ChartType] = [
+    ChartType.line,
+    ChartType.column,
+    ChartType.bar,
+    ChartType.scatter,
+]
+DEFAULT_CHART_TYPE: ChartType = ChartType.line
 
 
 class IndicatorBase(BaseModel):
@@ -16,6 +26,30 @@ class IndicatorBase(BaseModel):
     scale: Optional[str] = None
     unit: Optional[str] = None
     carrying_capacity: Optional[str] = None
+    chart_types: List[ChartType] = Field(default_factory=lambda: list(DEFAULT_CHART_TYPES))
+    default_chart_type: ChartType = DEFAULT_CHART_TYPE
+
+    @field_validator("chart_types")
+    @classmethod
+    def _chart_types_non_empty(cls, v: List[ChartType]) -> List[ChartType]:
+        if not v:
+            raise ValueError("chart_types must contain at least one chart type")
+        # Deduplicate while preserving order
+        seen = set()
+        unique = []
+        for t in v:
+            if t not in seen:
+                seen.add(t)
+                unique.append(t)
+        return unique
+
+    @model_validator(mode="after")
+    def _default_in_chart_types(self) -> "IndicatorBase":
+        if self.default_chart_type not in self.chart_types:
+            raise ValueError(
+                "default_chart_type must be one of the values in chart_types"
+            )
+        return self
 
 
 class IndicatorCreate(IndicatorBase):
@@ -43,6 +77,22 @@ class IndicatorPatch(BaseModel):
     scale: Optional[str] = None
     unit: Optional[str] = None
     carrying_capacity: Optional[str] = None
+    chart_types: Optional[List[ChartType]] = None
+    default_chart_type: Optional[ChartType] = None
+
+    @model_validator(mode="after")
+    def _patch_chart_consistency(self) -> "IndicatorPatch":
+        if self.chart_types is not None and len(self.chart_types) == 0:
+            raise ValueError("chart_types must contain at least one chart type")
+        if (
+            self.chart_types is not None
+            and self.default_chart_type is not None
+            and self.default_chart_type not in self.chart_types
+        ):
+            raise ValueError(
+                "default_chart_type must be one of the values in chart_types"
+            )
+        return self
 
 
 class Indicator(IndicatorBase):

--- a/app/services/chart_export_service.py
+++ b/app/services/chart_export_service.py
@@ -52,16 +52,39 @@ class ChartExportService:
             fig.add_trace(go.Scatter(x=x_values, y=y_values, mode='markers', marker=dict(color=request.colors[0] if request.colors else None)))
         elif request.chart_type in (ChartType.pie, ChartType.donut):
             hole = 0.5 if request.chart_type == ChartType.donut else 0
-            fig.add_trace(go.Pie(labels=x_values, values=y_values, hole=hole))
+            pie_kwargs = {"labels": x_values, "values": y_values, "hole": hole}
+            if request.colors:
+                pie_kwargs["marker"] = {"colors": request.colors}
+            fig.add_trace(go.Pie(**pie_kwargs))
         elif request.chart_type == ChartType.treemap:
-            fig.add_trace(go.Treemap(labels=x_values, parents=[""] * len(x_values), values=y_values))
+            treemap_kwargs = {
+                "labels": x_values,
+                "parents": [""] * len(x_values),
+                "values": y_values,
+            }
+            if request.colors:
+                treemap_kwargs["marker"] = {"colors": request.colors}
+            fig.add_trace(go.Treemap(**treemap_kwargs))
         elif request.chart_type == ChartType.heatmap:
             # Single-row heatmap with x as columns, one constant row.
-            fig.add_trace(go.Heatmap(x=x_values, y=["value"], z=[y_values]))
+            heatmap_kwargs = {"x": x_values, "y": ["value"], "z": [y_values]}
+            if request.colors:
+                # Spread the supplied palette across a continuous colorscale.
+                n = len(request.colors)
+                if n == 1:
+                    heatmap_kwargs["colorscale"] = [[0, request.colors[0]], [1, request.colors[0]]]
+                else:
+                    heatmap_kwargs["colorscale"] = [
+                        [i / (n - 1), c] for i, c in enumerate(request.colors)
+                    ]
+            fig.add_trace(go.Heatmap(**heatmap_kwargs))
         else:
             # Types requiring shape-specific data (box plot, candlestick,
-            # range bar, range area) can't be produced from flat {x,y}.
-            return self._create_empty_chart_image(request)
+            # range bar, range area) can't be produced from flat {x, y}.
+            # Surface that to the user rather than the generic "No Data".
+            return self._create_empty_chart_image(
+                request, message="Chart type not supported for this data"
+            )
 
         # 4. Apply Layout & Styling
         template = "plotly_white" if request.theme == ThemeMode.light else "plotly_dark"
@@ -127,7 +150,9 @@ class ChartExportService:
         img_bytes = fig.to_image(format="png", scale=2)
         return img_bytes
 
-    def _create_empty_chart_image(self, request: ChartExportRequest) -> bytes:
+    def _create_empty_chart_image(
+        self, request: ChartExportRequest, message: str = "No Data Available"
+    ) -> bytes:
         fig = go.Figure()
         fig.update_layout(
             width=request.width,
@@ -136,7 +161,7 @@ class ChartExportService:
             yaxis={"visible": False},
             annotations=[
                 {
-                    "text": "No Data Available",
+                    "text": message,
                     "xref": "paper",
                     "yref": "paper",
                     "showarrow": False,

--- a/app/services/chart_export_service.py
+++ b/app/services/chart_export_service.py
@@ -50,6 +50,18 @@ class ChartExportService:
             fig.add_trace(go.Bar(x=x_values, y=y_values, marker_color=request.colors[0] if request.colors else None))
         elif request.chart_type == ChartType.scatter:
             fig.add_trace(go.Scatter(x=x_values, y=y_values, mode='markers', marker=dict(color=request.colors[0] if request.colors else None)))
+        elif request.chart_type in (ChartType.pie, ChartType.donut):
+            hole = 0.5 if request.chart_type == ChartType.donut else 0
+            fig.add_trace(go.Pie(labels=x_values, values=y_values, hole=hole))
+        elif request.chart_type == ChartType.treemap:
+            fig.add_trace(go.Treemap(labels=x_values, parents=[""] * len(x_values), values=y_values))
+        elif request.chart_type == ChartType.heatmap:
+            # Single-row heatmap with x as columns, one constant row.
+            fig.add_trace(go.Heatmap(x=x_values, y=["value"], z=[y_values]))
+        else:
+            # Types requiring shape-specific data (box plot, candlestick,
+            # range bar, range area) can't be produced from flat {x,y}.
+            return self._create_empty_chart_image(request)
 
         # 4. Apply Layout & Styling
         template = "plotly_white" if request.theme == ThemeMode.light else "plotly_dark"


### PR DESCRIPTION
This pull request introduces several enhancements to chart type support and validation in the indicator schemas, as well as improvements to authentication error handling. The main changes include expanding the supported chart types, adding validation to ensure consistency between chart types and defaults, updating chart image generation to support new types, and refactoring authentication logic for better error reporting.

**Chart type support and validation:**

* Added new chart types (`pie`, `donut`, `treemap`, `heatmap`, `boxPlot`, `candlestick`, `rangeBar`, `rangeArea`) to the `ChartType` enum in `app/schemas/chart_export.py`.
* Introduced `chart_types` and `default_chart_type` fields to `IndicatorBase` and `IndicatorPatch` in `app/schemas/indicator.py`, with validation to ensure `chart_types` is non-empty and `default_chart_type` is included in `chart_types`. [[1]](diffhunk://#diff-1d31a6594d5de3a0aa97060138fa4e3f836cd21d7b1306b0b6c19a5f40e03311R29-R52) [[2]](diffhunk://#diff-1d31a6594d5de3a0aa97060138fa4e3f836cd21d7b1306b0b6c19a5f40e03311R80-R95)
* Defined default chart types and the default chart type for indicators.

**Chart image generation:**

* Updated `generate_chart_image` in `app/services/chart_export_service.py` to support rendering for the new chart types (`pie`, `donut`, `treemap`, `heatmap`) and fallback for unsupported types.

**Authentication improvements:**

* Refactored authentication logic in `app/auth.py` to centralize token decoding and improve error handling, including distinguishing between invalid tokens and authentication service unavailability.