### PR TITLE
hide areas and dimensions

### DIFF
--- a/app/routes/domain_routes.py
+++ b/app/routes/domain_routes.py
@@ -20,8 +20,8 @@ INVALID_DOMAIN_ID = "Invalid domain ID"
 router = APIRouter()
 
 @router.get("/", response_model=List[Domain])
-async def get_domains():
-    return await get_all_domains()
+async def get_domains(include_hidden: bool = False):
+    return await get_all_domains(include_hidden=include_hidden)
 
 @router.get("/{domain_id}", response_model=Domain)
 async def get_domain(domain_id: str):

--- a/app/schemas/domain.py
+++ b/app/schemas/domain.py
@@ -42,7 +42,10 @@ class DomainUpdate(BaseModel):
     color: str
     image: Optional[str] = ""
     icon: Optional[str] = ""
-    hidden: bool = False
+    # Optional so clients that omit `hidden` in a PUT don't silently unhide an
+    # already-hidden domain. Use `exclude_unset=True` in the service when
+    # building the $set document.
+    hidden: Optional[bool] = None
     subdomains: List[Union[Subdomain, str]]
 
     @field_validator("subdomains", mode="before")

--- a/app/schemas/domain.py
+++ b/app/schemas/domain.py
@@ -6,6 +6,7 @@ from schemas.common import PyObjectId
 class Subdomain(BaseModel):
     name: str
     name_en: Optional[str] = ""
+    hidden: bool = False
 
 
 class DomainBase(BaseModel):
@@ -14,6 +15,7 @@ class DomainBase(BaseModel):
     color: str
     image: Optional[str] = ""
     icon: Optional[str] = ""
+    hidden: bool = False
     subdomains: List[Union[Subdomain, str]]
 
     @field_validator("subdomains", mode="before")
@@ -40,6 +42,7 @@ class DomainUpdate(BaseModel):
     color: str
     image: Optional[str] = ""
     icon: Optional[str] = ""
+    hidden: bool = False
     subdomains: List[Union[Subdomain, str]]
 
     @field_validator("subdomains", mode="before")
@@ -62,6 +65,7 @@ class DomainPatch(BaseModel):
     color: Optional[str] = None
     image: Optional[str] = None
     icon: Optional[str] = None
+    hidden: Optional[bool] = None
     subdomains: Optional[List[Union[Subdomain, str]]] = None
 
     @field_validator("subdomains", mode="before")

--- a/app/services/domain_service.py
+++ b/app/services/domain_service.py
@@ -29,14 +29,28 @@ async def get_hidden_dimension_keys() -> List[dict]:
     return keys
 
 
-async def is_subdomain_hidden(domain_id: str, subdomain_name: str) -> bool:
-    """Check if a specific subdomain is marked hidden."""
+async def is_domain_hidden(domain_id: str) -> bool:
+    """Check if a domain is marked hidden (or has been deleted)."""
     domain = await db.domains.find_one(
         {"_id": ObjectId(domain_id), "deleted": False},
-        {"subdomains": 1},
+        {"hidden": 1},
     )
     if not domain:
-        return False
+        return True
+    return bool(domain.get("hidden"))
+
+
+async def is_subdomain_hidden(domain_id: str, subdomain_name: str) -> bool:
+    """Check if a specific subdomain is hidden — also treats the subdomain as
+    hidden when its parent domain is itself hidden."""
+    domain = await db.domains.find_one(
+        {"_id": ObjectId(domain_id), "deleted": False},
+        {"hidden": 1, "subdomains": 1},
+    )
+    if not domain:
+        return True
+    if domain.get("hidden"):
+        return True
     for sub in domain.get("subdomains") or []:
         if isinstance(sub, dict) and sub.get("name") == subdomain_name:
             return bool(sub.get("hidden"))
@@ -57,9 +71,15 @@ async def create_domain(domain_data: DomainCreate) -> Optional[dict]:
     return None
 
 async def update_domain(domain_id: str, domain_data: DomainUpdate) -> Optional[dict]:
+    # `exclude_unset=True` so a PUT that omits `hidden` doesn't silently
+    # unhide an already-hidden domain — the $set only touches fields that
+    # the client actually sent.
+    update_payload = domain_data.dict(exclude_unset=True)
+    if not update_payload:
+        return await get_domain_by_id(domain_id)
     result = await db.domains.update_one(
         {"_id": ObjectId(domain_id), "deleted": False},
-        {"$set": domain_data.dict()}
+        {"$set": update_payload}
     )
     if result.matched_count > 0:
         return await get_domain_by_id(domain_id)

--- a/app/services/domain_service.py
+++ b/app/services/domain_service.py
@@ -4,9 +4,44 @@ from dependencies.database import db
 from utils.mongo_utils import serialize
 from schemas.domain import DomainCreate, DomainUpdate, DomainPatch, DomainDelete
 
-async def get_all_domains() -> List[dict]:
-    domains = await db.domains.find({"deleted": False}).to_list(100)
+async def get_all_domains(include_hidden: bool = False) -> List[dict]:
+    filter_criteria = {"deleted": False}
+    if not include_hidden:
+        filter_criteria["hidden"] = {"$ne": True}
+    domains = await db.domains.find(filter_criteria).to_list(100)
     return [serialize(domain) for domain in domains]
+
+
+async def get_hidden_domain_ids() -> List[ObjectId]:
+    """Return ObjectIds of every non-deleted, hidden domain."""
+    cursor = db.domains.find({"deleted": False, "hidden": True}, {"_id": 1})
+    return [doc["_id"] async for doc in cursor]
+
+
+async def get_hidden_dimension_keys() -> List[dict]:
+    """Return {domain, subdomain} pairs for every hidden subdomain in every non-deleted domain."""
+    cursor = db.domains.find({"deleted": False}, {"_id": 1, "subdomains": 1})
+    keys = []
+    async for doc in cursor:
+        for sub in doc.get("subdomains") or []:
+            if isinstance(sub, dict) and sub.get("hidden") and sub.get("name"):
+                keys.append({"domain": doc["_id"], "subdomain": sub["name"]})
+    return keys
+
+
+async def is_subdomain_hidden(domain_id: str, subdomain_name: str) -> bool:
+    """Check if a specific subdomain is marked hidden."""
+    domain = await db.domains.find_one(
+        {"_id": ObjectId(domain_id), "deleted": False},
+        {"subdomains": 1},
+    )
+    if not domain:
+        return False
+    for sub in domain.get("subdomains") or []:
+        if isinstance(sub, dict) and sub.get("name") == subdomain_name:
+            return bool(sub.get("hidden"))
+    return False
+
 
 async def get_domain_by_id(domain_id: str) -> Optional[dict]:
     domain = await db.domains.find_one({"_id": ObjectId(domain_id), "deleted": False})
@@ -15,6 +50,7 @@ async def get_domain_by_id(domain_id: str) -> Optional[dict]:
 async def create_domain(domain_data: DomainCreate) -> Optional[dict]:
     domain_dict = domain_data.dict()
     domain_dict["deleted"] = False
+    domain_dict.setdefault("hidden", False)
     result = await db.domains.insert_one(domain_dict)
     if result.inserted_id:
         return await get_domain_by_id(str(result.inserted_id))

--- a/app/services/indicator_service.py
+++ b/app/services/indicator_service.py
@@ -7,6 +7,7 @@ from schemas.indicator import IndicatorCreate, IndicatorDelete
 from services.domain_service import (
     get_hidden_domain_ids,
     get_hidden_dimension_keys,
+    is_domain_hidden,
     is_subdomain_hidden,
 )
 from utils.mongo_utils import serialize, deserialize
@@ -120,6 +121,8 @@ async def get_indicators_count_by_domain(
     domain_id: str, governance_filter: bool = None, include_hidden: bool = False
 ) -> int:
     """Get total count of indicators for a specific domain"""
+    if not include_hidden and await is_domain_hidden(domain_id):
+        return 0
     filter_criteria = {"domain": ObjectId(domain_id), "deleted": False}
     if not include_hidden:
         filter_criteria["hidden"] = {"$ne": True}
@@ -400,6 +403,8 @@ async def get_indicators_by_domain(
     sort_criteria = [(db_field, sort_direction)]
 
     # Build filter criteria
+    if not include_hidden and await is_domain_hidden(domain_id):
+        return []
     filter_criteria = {"domain": ObjectId(domain_id), "deleted": False}
     if not include_hidden:
         filter_criteria["hidden"] = {"$ne": True}

--- a/app/services/indicator_service.py
+++ b/app/services/indicator_service.py
@@ -1,12 +1,31 @@
 from typing import List, Optional
 from bson.objectid import ObjectId
+from pymongo.collation import Collation
 from pymongo.errors import ConnectionFailure, ServerSelectionTimeoutError
 from dependencies.database import db
 from schemas.indicator import IndicatorCreate, IndicatorDelete
+from services.domain_service import (
+    get_hidden_domain_ids,
+    get_hidden_dimension_keys,
+    is_subdomain_hidden,
+)
 from utils.mongo_utils import serialize, deserialize
 import logging
+import unicodedata
+
+
+def _pt_sort_key(s: str) -> str:
+    """Accent-insensitive, case-insensitive sort key for Portuguese strings."""
+    if not s:
+        return ""
+    nfkd = unicodedata.normalize("NFKD", s)
+    return "".join(c for c in nfkd if not unicodedata.combining(c)).casefold()
 
 logger = logging.getLogger(__name__)
+
+# Portuguese locale collation for accent-aware alphabetical sorting.
+# strength=1 treats "Á" and "a" as equal for ordering.
+PT_COLLATION = Collation(locale="pt", strength=1)
 
 
 async def create_indicator(
@@ -62,11 +81,18 @@ async def get_all_indicators(
     filter_criteria = {"deleted": False}
     if not include_hidden:
         filter_criteria["hidden"] = {"$ne": True}
+        hidden_domains = await get_hidden_domain_ids()
+        if hidden_domains:
+            filter_criteria["domain"] = {"$nin": hidden_domains}
+        hidden_dims = await get_hidden_dimension_keys()
+        if hidden_dims:
+            filter_criteria["$nor"] = hidden_dims
     if governance_filter is not None:
         filter_criteria["governance"] = governance_filter
 
     indicators = (
         await db.indicators.find(filter_criteria)
+        .collation(PT_COLLATION)
         .sort(sort_criteria)
         .skip(skip)
         .limit(limit)
@@ -80,6 +106,12 @@ async def get_indicators_count(include_hidden: bool = False) -> int:
     filter_criteria = {"deleted": False}
     if not include_hidden:
         filter_criteria["hidden"] = {"$ne": True}
+        hidden_domains = await get_hidden_domain_ids()
+        if hidden_domains:
+            filter_criteria["domain"] = {"$nin": hidden_domains}
+        hidden_dims = await get_hidden_dimension_keys()
+        if hidden_dims:
+            filter_criteria["$nor"] = hidden_dims
     count = await db.indicators.count_documents(filter_criteria)
     return count
 
@@ -91,6 +123,10 @@ async def get_indicators_count_by_domain(
     filter_criteria = {"domain": ObjectId(domain_id), "deleted": False}
     if not include_hidden:
         filter_criteria["hidden"] = {"$ne": True}
+        hidden_dims = await get_hidden_dimension_keys()
+        hidden_subs_here = [k["subdomain"] for k in hidden_dims if k["domain"] == ObjectId(domain_id)]
+        if hidden_subs_here:
+            filter_criteria["subdomain"] = {"$nin": hidden_subs_here}
     if governance_filter is not None:
         filter_criteria["governance"] = governance_filter
 
@@ -102,6 +138,8 @@ async def get_indicators_count_by_subdomain(
     domain_id: str, subdomain_name: str, governance_filter: bool = None, include_hidden: bool = False
 ) -> int:
     """Get total count of indicators for a specific subdomain"""
+    if not include_hidden and await is_subdomain_hidden(domain_id, subdomain_name):
+        return 0
     filter_criteria = {
         "domain": ObjectId(domain_id),
         "subdomain": subdomain_name,
@@ -155,6 +193,12 @@ async def search_indicators(
         base_filters = [{"deleted": False}]
         if not include_hidden:
             base_filters.append({"hidden": {"$ne": True}})
+            hidden_domains = await get_hidden_domain_ids()
+            if hidden_domains:
+                base_filters.append({"domain": {"$nin": hidden_domains}})
+            hidden_dims = await get_hidden_dimension_keys()
+            if hidden_dims:
+                base_filters.append({"$nor": hidden_dims})
         search_criteria = {"$and": base_filters + [{"$or": word_patterns}]}
 
         # Add governance filter if specified
@@ -190,9 +234,12 @@ async def search_indicators(
         else:
             # Sort by specified field
             reverse_order = sort_order.lower() == "desc"
-            scored_indicators.sort(
-                key=lambda x: x[0].get(sort_by, ""), reverse=reverse_order
+            key_fn = (
+                (lambda x: _pt_sort_key(x[0].get(sort_by, "")))
+                if sort_by == "name"
+                else (lambda x: x[0].get(sort_by, ""))
             )
+            scored_indicators.sort(key=key_fn, reverse=reverse_order)
 
         # Apply pagination after sorting
         paginated_indicators = scored_indicators[skip : skip + limit]
@@ -356,11 +403,16 @@ async def get_indicators_by_domain(
     filter_criteria = {"domain": ObjectId(domain_id), "deleted": False}
     if not include_hidden:
         filter_criteria["hidden"] = {"$ne": True}
+        hidden_dims = await get_hidden_dimension_keys()
+        hidden_subs_here = [k["subdomain"] for k in hidden_dims if k["domain"] == ObjectId(domain_id)]
+        if hidden_subs_here:
+            filter_criteria["subdomain"] = {"$nin": hidden_subs_here}
     if governance_filter is not None:
         filter_criteria["governance"] = governance_filter
 
     indicators = (
         await db.indicators.find(filter_criteria)
+        .collation(PT_COLLATION)
         .sort(sort_criteria)
         .skip(skip)
         .limit(limit)
@@ -379,6 +431,9 @@ async def get_indicators_by_subdomain(
     governance_filter: bool = None,
     include_hidden: bool = False,
 ) -> List[dict]:
+    if not include_hidden and await is_subdomain_hidden(domain_id, subdomain_name):
+        return []
+
     # Define sort order
     sort_direction = 1 if sort_order.lower() == "asc" else -1
 
@@ -408,6 +463,7 @@ async def get_indicators_by_subdomain(
 
     indicators = (
         await db.indicators.find(filter_criteria)
+        .collation(PT_COLLATION)
         .sort(sort_criteria)
         .skip(skip)
         .limit(limit)


### PR DESCRIPTION
This pull request introduces support for hiding domains and subdomains, ensuring that hidden items are excluded from API responses and related indicator queries unless explicitly requested. It also improves sorting of indicators by name using accent-insensitive, case-insensitive logic for Portuguese. The changes span schema updates, database query logic, and service methods.

**Hidden domains and subdomains support:**

* Added a `hidden` boolean field to the `Domain`, `Subdomain`, and their related Pydantic schemas (`DomainBase`, `DomainUpdate`, `DomainPatch`) to mark domains and subdomains as hidden. [[1]](diffhunk://#diff-30ab67d0225aeb46300e5219b68fcb4bc0bea5f8621924ac2ae574627c6121f5R9) [[2]](diffhunk://#diff-30ab67d0225aeb46300e5219b68fcb4bc0bea5f8621924ac2ae574627c6121f5R18) [[3]](diffhunk://#diff-30ab67d0225aeb46300e5219b68fcb4bc0bea5f8621924ac2ae574627c6121f5R45) [[4]](diffhunk://#diff-30ab67d0225aeb46300e5219b68fcb4bc0bea5f8621924ac2ae574627c6121f5R68)
* Updated the `get_domains` route and `get_all_domains` service to support an `include_hidden` parameter, filtering out hidden domains by default. [[1]](diffhunk://#diff-02191908ef34c6dc7dc957330fdada28a58b0d5e5c948a1438cb50020c3bf99bL23-R24) [[2]](diffhunk://#diff-57150d91c6a51c1502d2560bb95792d48deaaa6c8a842682cde018f0740a19abL7-R53)
* Added service methods to retrieve hidden domain IDs, hidden subdomain keys, and to check if a subdomain is hidden. These are used to exclude hidden items from indicator queries.

**Indicator query and count logic:**

* Modified all indicator-related service methods (`get_all_indicators`, `get_indicators_count`, `get_indicators_count_by_domain`, `get_indicators_count_by_subdomain`, `search_indicators`, `get_indicators_by_domain`, `get_indicators_by_subdomain`) to exclude hidden domains and subdomains unless `include_hidden` is true. [[1]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR84-R95) [[2]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR109-R114) [[3]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR126-R129) [[4]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR141-R142) [[5]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR196-R201) [[6]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR406-R415) [[7]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR434-R436)

**Sorting improvements:**

* Introduced accent-insensitive, case-insensitive sorting for indicator names in Portuguese using a custom sort key and MongoDB collation. This ensures that indicators are sorted correctly regardless of accents or case. [[1]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR3-R29) [[2]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR84-R95) [[3]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cL193-R242) [[4]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR406-R415) [[5]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR466)