### PR TITLE
Feature/composed indicators

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,9 @@ class Settings(BaseSettings):
     RESOURCE_DELETED_QUEUE: str = Field(
         default="resource_deleted", env="RESOURCE_DELETED_QUEUE"
     )
+    WRAPPER_TRANSLATIONS_QUEUE: str = Field(
+        default="wrapper_translations", env="WRAPPER_TRANSLATIONS_QUEUE"
+    )
     REDIS_URL: str = Field(default="redis://indicators-redis:6379", env="REDIS_URL")
 
     # Cache settings

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from contextlib import asynccontextmanager
 from config import settings
 import services.data_ingestor  # noqa
 import services.resource_cleanup  # noqa
+import services.series_translations  # noqa
 
 logger = logging.getLogger(__name__)
 

--- a/app/routes/data_routes.py
+++ b/app/routes/data_routes.py
@@ -2,10 +2,10 @@ from fastapi import APIRouter, HTTPException, Query, BackgroundTasks, Response
 from typing import List, Optional
 from datetime import datetime
 import re
-from schemas.data_segment import DataPoint
+from schemas.data_segment import DataPoint, IndicatorSeries
 from schemas.common import PyObjectId
 from bson.errors import InvalidId
-from services.data_propagator import get_data_points
+from services.data_propagator import get_data_points, get_series_data_points
 from services.statistics_service import get_indicator_statistics
 from schemas.statistics import IndicatorStatistics
 from config import settings
@@ -57,6 +57,34 @@ async def get_indicator_data(
     )
     response.headers["X-Total-Count"] = str(len(points))
     return points
+
+
+@router.get("/{indicator_id}/series", response_model=List[IndicatorSeries])
+async def get_indicator_series(
+    indicator_id: str,
+    response: Response,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(1000, ge=1, le=10000),
+    sort: str = Query("asc", regex="^(asc|desc)$"),
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+):
+    """One timeseries per resource. Each entry feeds a separate line on the chart."""
+    try:
+        PyObjectId(indicator_id)
+    except (InvalidId, ValueError):
+        raise HTTPException(status_code=400, detail=INVALID_INDICATOR_ID)
+
+    series = await get_series_data_points(
+        indicator_id,
+        sort=sort,
+        skip=skip,
+        limit=limit,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    response.headers["X-Total-Count"] = str(len(series))
+    return series
 
 
 @router.get("/{indicator_id}/statistics", response_model=IndicatorStatistics)

--- a/app/routes/data_routes.py
+++ b/app/routes/data_routes.py
@@ -75,14 +75,17 @@ async def get_indicator_series(
     except (InvalidId, ValueError):
         raise HTTPException(status_code=400, detail=INVALID_INDICATOR_ID)
 
-    series = await get_series_data_points(
-        indicator_id,
-        sort=sort,
-        skip=skip,
-        limit=limit,
-        start_date=start_date,
-        end_date=end_date,
-    )
+    try:
+        series = await get_series_data_points(
+            indicator_id,
+            sort=sort,
+            skip=skip,
+            limit=limit,
+            start_date=start_date,
+            end_date=end_date,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     response.headers["X-Total-Count"] = str(len(series))
     return series
 

--- a/app/schemas/chart_export.py
+++ b/app/schemas/chart_export.py
@@ -9,6 +9,8 @@ class ChartType(str, Enum):
     area = "area"
     bar = "bar"
     column = "column"
+    stackedColumn = "stackedColumn"
+    stackedBar = "stackedBar"
     scatter = "scatter"
     # Aggregate visualizations: derived from {x,y} time-series data
     pie = "pie"

--- a/app/schemas/data_segment.py
+++ b/app/schemas/data_segment.py
@@ -7,11 +7,16 @@ from schemas.common import PyObjectId
 class DataPoint(BaseModel):
     x: datetime | float
     y: float
+    # Optional series label. Multi-column files (one resource → many series)
+    # tag each emitted point with the column name; single-source resources
+    # leave it None.
+    series: Optional[str] = None
 
 
 class TimePoint(BaseModel):
     x: datetime
     y: float
+    series: Optional[str] = None
 
 
 class DataSegmentBase(BaseModel):
@@ -33,3 +38,13 @@ class MergedIndicator(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class IndicatorSeries(BaseModel):
+    """One line on the chart. Identified by (resource_id, series_label):
+    a single resource can contribute several series when the source file has
+    multiple value columns. series_label is None for legacy single-stream
+    resources (one wrapper → one untagged series)."""
+    resource_id: str
+    series_label: Optional[str] = None
+    points: List[DataPoint]

--- a/app/schemas/indicator.py
+++ b/app/schemas/indicator.py
@@ -1,8 +1,20 @@
 from pydantic import BaseModel, Field, field_validator, model_validator
-from typing import Optional, List
+from typing import Optional, List, Dict
 from schemas.domain import Domain
 from schemas.common import PyObjectId
 from schemas.chart_export import ChartType
+
+
+class SeriesTranslation(BaseModel):
+    """PT/EN labels for a single data column (series_label).
+
+    Seeded by the resource-service Gemini sidecar, editable in the admin
+    indicator wizard. Either side may be empty if the source language is
+    already the target.
+    """
+
+    pt: str = ""
+    en: str = ""
 
 
 DEFAULT_CHART_TYPES: List[ChartType] = [
@@ -32,6 +44,15 @@ class IndicatorBase(BaseModel):
     carrying_capacity: Optional[str] = None
     chart_types: List[ChartType] = Field(default_factory=lambda: list(DEFAULT_CHART_TYPES))
     default_chart_type: ChartType = DEFAULT_CHART_TYPE
+    # Series labels (column names from data wrappers) the admin has toggled
+    # off. The public chart filters these out so the data stays in storage but
+    # is hidden from end users — same lever as the wrapper-time column picker
+    # but applied post hoc, without re-running the wrapper.
+    hidden_series: List[str] = Field(default_factory=list)
+    # PT/EN translations for each series_label, keyed by the original label
+    # from the data wrapper. Seeded by resource-service after wrapper
+    # completion (Gemini sidecar) and editable in the admin wizard.
+    series_translations: Dict[str, SeriesTranslation] = Field(default_factory=dict)
 
     @field_validator("chart_types")
     @classmethod
@@ -87,6 +108,8 @@ class IndicatorPatch(BaseModel):
     carrying_capacity: Optional[str] = None
     chart_types: Optional[List[ChartType]] = None
     default_chart_type: Optional[ChartType] = None
+    hidden_series: Optional[List[str]] = None
+    series_translations: Optional[Dict[str, SeriesTranslation]] = None
 
     @model_validator(mode="after")
     def _patch_chart_consistency(self) -> "IndicatorPatch":

--- a/app/services/data_ingestor.py
+++ b/app/services/data_ingestor.py
@@ -56,17 +56,20 @@ async def merge_indicator_data(indicator_id: str) -> list[DataPoint]:
         if not segment_timestamp:
             continue
 
+        seg_ts = segment_timestamp.replace(tzinfo=None) if segment_timestamp.tzinfo else segment_timestamp
+
         for point in segment["points"]:
             series = point.get("series")
             if isinstance(point["x"], (str, datetime)):
-                x_value = datetime.fromisoformat(point["x"].replace(
+                raw = datetime.fromisoformat(point["x"].replace(
                     'Z', '+00:00')) if isinstance(point["x"], str) else point["x"]
+                x_value = raw.replace(tzinfo=None) if raw.tzinfo else raw
 
                 key = (x_value, series)
                 current = time_series_points.get(key)
-                if not current or segment_timestamp > current[1]:
+                if not current or seg_ts > current[1]:
                     time_series_points[key] = (
-                            point["y"], segment_timestamp)
+                            point["y"], seg_ts)
             else:
                 numeric_points.append(
                         DataPoint(x=float(point["x"]), y=float(point["y"]), series=series))

--- a/app/services/data_ingestor.py
+++ b/app/services/data_ingestor.py
@@ -33,7 +33,12 @@ async def delete_keys_by_prefix(redis_client, prefix):
     return 0
 
 async def merge_indicator_data(indicator_id: str) -> list[DataPoint]:
-    """Merge all segments for an indicator into sorted data points"""
+    """Merge all segments for an indicator into sorted data points.
+
+    Dedup key is (x, series) — multi-series wrappers (one resource → many
+    columns) emit several points at the same x, one per column. Series-less
+    points share the (x, None) key, preserving the legacy single-stream flow.
+    """
     from typing import Dict, Tuple
     from datetime import datetime
     from bson.objectid import ObjectId
@@ -42,7 +47,8 @@ async def merge_indicator_data(indicator_id: str) -> list[DataPoint]:
             {"indicator_id": ObjectId(indicator_id)}
             ).to_list(None)
 
-    time_series_points: Dict[datetime, Tuple[float, datetime]] = {}
+    # Key: (x_value, series_label). Value: (y, segment_timestamp)
+    time_series_points: Dict[Tuple, Tuple[float, datetime]] = {}
     numeric_points = []
 
     for segment in segments:
@@ -51,22 +57,25 @@ async def merge_indicator_data(indicator_id: str) -> list[DataPoint]:
             continue
 
         for point in segment["points"]:
+            series = point.get("series")
             if isinstance(point["x"], (str, datetime)):
                 x_value = datetime.fromisoformat(point["x"].replace(
                     'Z', '+00:00')) if isinstance(point["x"], str) else point["x"]
 
-                current = time_series_points.get(x_value)
+                key = (x_value, series)
+                current = time_series_points.get(key)
                 if not current or segment_timestamp > current[1]:
-                    time_series_points[x_value] = (
+                    time_series_points[key] = (
                             point["y"], segment_timestamp)
             else:
                 numeric_points.append(
-                        DataPoint(x=float(point["x"]), y=float(point["y"])))
+                        DataPoint(x=float(point["x"]), y=float(point["y"]), series=series))
 
-    time_points = [DataPoint(x=x, y=y)
-                   for x, (y, _) in time_series_points.items()]
+    time_points = [DataPoint(x=x, y=y, series=series)
+                   for (x, series), (y, _) in time_series_points.items()]
 
-    # Sort all points in ascending order
+    # Sort all points in ascending order. Sorting by x alone is fine — the
+    # series field carries through.
     all_points = time_points + numeric_points
     sorted_points = sorted(all_points, key=lambda p: p.x)
 
@@ -145,8 +154,11 @@ async def process_message(message: aio_pika.abc.AbstractIncomingMessage):
                 await message.ack()  # Acknowledge and discard
                 return
 
-            # Convert points to TimePoint objects
-            data_points = [TimePoint(x=p['x'], y=p['y']) for p in points]
+            # Convert points to TimePoint objects. Preserve the optional
+            # `series` field — multi-column wrappers tag each point with its
+            # column name so /series can split the resource's data into
+            # parallel lines.
+            data_points = [TimePoint(x=p['x'], y=p['y'], series=p.get('series')) for p in points]
 
             # Create and store data segment
             segment = DataSegment(

--- a/app/services/data_propagator.py
+++ b/app/services/data_propagator.py
@@ -509,18 +509,13 @@ async def get_data_points(
     )
 
 
-async def _merge_resource_segments(indicator_id: str, resource_id) -> List[DataPoint]:
-    """Merge all segments for a single (indicator, resource) into sorted points.
+def _merge_segments(segments: list) -> List[DataPoint]:
+    """Merge a pre-fetched list of segments for one (indicator, resource) into sorted points.
 
     Dedup key is (x, series) — same rule as merge_indicator_data. Distinct
     series within a resource stay distinct (one chart line each); legacy
     series-less points share the (x, None) key.
     """
-    segments = await db.data_segments.find({
-        "indicator_id": ObjectId(indicator_id),
-        "resource_id": resource_id,
-    }).to_list(None)
-
     time_points: Dict[tuple, tuple] = {}
     numeric_points: List[DataPoint] = []
 
@@ -533,11 +528,11 @@ async def _merge_resource_segments(indicator_id: str, resource_id) -> List[DataP
             series = point.get("series")
             if isinstance(x_raw, str):
                 try:
-                    x_val = datetime.fromisoformat(x_raw.replace("Z", "+00:00"))
+                    x_val = _to_naive_utc(datetime.fromisoformat(x_raw.replace("Z", "+00:00")))
                 except ValueError:
                     continue
             else:
-                x_val = x_raw
+                x_val = _to_naive_utc(x_raw) if isinstance(x_raw, datetime) else x_raw
 
             if isinstance(x_val, datetime):
                 key = (x_val, series)
@@ -590,14 +585,18 @@ async def get_series_data_points(
     if sd and ed and sd > ed:
         raise ValueError("start_date must be before end_date")
 
-    resource_ids = await db.data_segments.distinct(
-        "resource_id",
+    all_segments = await db.data_segments.find(
         {"indicator_id": ObjectId(indicator_id)},
-    )
+    ).to_list(None)
+
+    segments_by_resource: Dict[Any, list] = {}
+    for seg in all_segments:
+        rid = seg.get("resource_id")
+        segments_by_resource.setdefault(rid, []).append(seg)
 
     series_list: List[Dict[str, Any]] = []
-    for rid in resource_ids:
-        points = await _merge_resource_segments(indicator_id, rid)
+    for rid, segments in segments_by_resource.items():
+        points = _merge_segments(segments)
 
         if sd or ed:
             def _in_range(p):
@@ -612,8 +611,13 @@ async def get_series_data_points(
         for p in points:
             by_series.setdefault(p.series, []).append(p)
 
+        def _point_sort_key(p):
+            if isinstance(p.x, datetime):
+                return (0, _to_naive_utc(p.x), 0.0)
+            return (1, datetime.min, float(p.x))
+
         for series_label, group in by_series.items():
-            group.sort(key=lambda p: p.x, reverse=(sort == "desc"))
+            group.sort(key=_point_sort_key, reverse=(sort == "desc"))
             paged = group[skip:skip + limit]
             series_list.append({
                 "resource_id": str(rid),

--- a/app/services/data_propagator.py
+++ b/app/services/data_propagator.py
@@ -554,6 +554,20 @@ async def _merge_resource_segments(indicator_id: str, resource_id) -> List[DataP
     return sorted(pts, key=lambda p: p.x)
 
 
+def _to_naive_utc(dt: Optional[datetime]) -> Optional[datetime]:
+    """MongoDB returns naive UTC datetimes; FastAPI parses query strings
+    like `1993-01-01T00:00:00.000Z` as tz-aware. Comparing the two raises
+    TypeError ("can't compare offset-naive and offset-aware datetimes"),
+    so normalise everything to naive UTC before comparing.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt
+    from datetime import timezone
+    return dt.astimezone(timezone.utc).replace(tzinfo=None)
+
+
 async def get_series_data_points(
         indicator_id: str,
         sort: str = "asc",
@@ -571,7 +585,9 @@ async def get_series_data_points(
     series here — one entry per column. Resources with no series labels
     produce a single entry with series_label=None (legacy behaviour).
     """
-    if start_date and end_date and start_date > end_date:
+    sd = _to_naive_utc(start_date)
+    ed = _to_naive_utc(end_date)
+    if sd and ed and sd > ed:
         raise ValueError("start_date must be before end_date")
 
     resource_ids = await db.data_segments.distinct(
@@ -583,13 +599,13 @@ async def get_series_data_points(
     for rid in resource_ids:
         points = await _merge_resource_segments(indicator_id, rid)
 
-        if start_date or end_date:
-            points = [
-                p for p in points
-                if isinstance(p.x, datetime)
-                and (not start_date or p.x >= start_date)
-                and (not end_date or p.x <= end_date)
-            ]
+        if sd or ed:
+            def _in_range(p):
+                if not isinstance(p.x, datetime):
+                    return True  # numeric x can't be date-filtered; keep
+                x = _to_naive_utc(p.x)
+                return (not sd or x >= sd) and (not ed or x <= ed)
+            points = [p for p in points if _in_range(p)]
 
         # Group by series label inside this resource.
         by_series: Dict[Optional[str], List[DataPoint]] = {}

--- a/app/services/data_propagator.py
+++ b/app/services/data_propagator.py
@@ -493,11 +493,11 @@ async def get_data_points(
         cache_params["start_date"] = start_date.isoformat()
     if end_date:
         cache_params["end_date"] = end_date.isoformat()
-    
+
     cache_key = get_cache_key(indicator_id, granularity, aggregator, **cache_params)
     pipeline = _build_query_pipeline(indicator_id, granularity, aggregator, sort, skip, limit, start_date, end_date)
     cache_processor = _build_cache_processor(sort, skip, limit, start_date, end_date)
-    
+
     return await _get_data_points(
         indicator_id=indicator_id,
         granularity=granularity,
@@ -507,5 +507,110 @@ async def get_data_points(
         full_cache_processor=cache_processor,
         background_tasks=background_tasks
     )
+
+
+async def _merge_resource_segments(indicator_id: str, resource_id) -> List[DataPoint]:
+    """Merge all segments for a single (indicator, resource) into sorted points.
+
+    Dedup key is (x, series) — same rule as merge_indicator_data. Distinct
+    series within a resource stay distinct (one chart line each); legacy
+    series-less points share the (x, None) key.
+    """
+    segments = await db.data_segments.find({
+        "indicator_id": ObjectId(indicator_id),
+        "resource_id": resource_id,
+    }).to_list(None)
+
+    time_points: Dict[tuple, tuple] = {}
+    numeric_points: List[DataPoint] = []
+
+    for segment in segments:
+        seg_ts = segment.get("timestamp")
+        if not seg_ts:
+            continue
+        for point in segment.get("points", []):
+            x_raw = point.get("x")
+            series = point.get("series")
+            if isinstance(x_raw, str):
+                try:
+                    x_val = datetime.fromisoformat(x_raw.replace("Z", "+00:00"))
+                except ValueError:
+                    continue
+            else:
+                x_val = x_raw
+
+            if isinstance(x_val, datetime):
+                key = (x_val, series)
+                cur = time_points.get(key)
+                if not cur or seg_ts > cur[1]:
+                    time_points[key] = (point["y"], seg_ts)
+            else:
+                try:
+                    numeric_points.append(DataPoint(x=float(x_val), y=float(point["y"]), series=series))
+                except (TypeError, ValueError):
+                    continue
+
+    pts = [DataPoint(x=x, y=y, series=series) for (x, series), (y, _) in time_points.items()] + numeric_points
+    return sorted(pts, key=lambda p: p.x)
+
+
+async def get_series_data_points(
+        indicator_id: str,
+        sort: str = "asc",
+        skip: int = 0,
+        limit: int = 1000,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
+) -> List[Dict[str, Any]]:
+    """One chart line per (resource_id, series_label) pair.
+
+    Returns: [{"resource_id": str, "series_label": str|None,
+               "points": [{"x": iso|float, "y": float}, ...]}, ...]
+
+    A single XLSX with N value columns lives in ONE resource but produces N
+    series here — one entry per column. Resources with no series labels
+    produce a single entry with series_label=None (legacy behaviour).
+    """
+    if start_date and end_date and start_date > end_date:
+        raise ValueError("start_date must be before end_date")
+
+    resource_ids = await db.data_segments.distinct(
+        "resource_id",
+        {"indicator_id": ObjectId(indicator_id)},
+    )
+
+    series_list: List[Dict[str, Any]] = []
+    for rid in resource_ids:
+        points = await _merge_resource_segments(indicator_id, rid)
+
+        if start_date or end_date:
+            points = [
+                p for p in points
+                if isinstance(p.x, datetime)
+                and (not start_date or p.x >= start_date)
+                and (not end_date or p.x <= end_date)
+            ]
+
+        # Group by series label inside this resource.
+        by_series: Dict[Optional[str], List[DataPoint]] = {}
+        for p in points:
+            by_series.setdefault(p.series, []).append(p)
+
+        for series_label, group in by_series.items():
+            group.sort(key=lambda p: p.x, reverse=(sort == "desc"))
+            paged = group[skip:skip + limit]
+            series_list.append({
+                "resource_id": str(rid),
+                "series_label": series_label,
+                "points": [
+                    {
+                        "x": p.x.isoformat() if isinstance(p.x, datetime) else float(p.x),
+                        "y": p.y,
+                    }
+                    for p in paged
+                ],
+            })
+
+    return series_list
 
 

--- a/app/services/series_translations.py
+++ b/app/services/series_translations.py
@@ -1,0 +1,70 @@
+"""Consumer for column-translation events from the resource-service Gemini
+sidecar. Merges PT/EN labels onto the indicator(s) attached to a resource.
+
+The wrapper-time translation is a seed: existing entries in
+indicator.series_translations are preserved on conflict so admin overrides
+(set via the indicator wizard) are never overwritten by a later
+re-generation.
+"""
+
+import json
+import logging
+
+import aio_pika
+
+from config import settings
+from dependencies.database import db
+from dependencies.rabbitmq import consumer
+
+
+logger = logging.getLogger(__name__)
+
+
+@consumer(settings.WRAPPER_TRANSLATIONS_QUEUE)
+async def process_wrapper_translations(
+    message: aio_pika.abc.AbstractIncomingMessage,
+):
+    async with message.process():
+        try:
+            payload = json.loads(message.body.decode())
+        except json.JSONDecodeError:
+            logger.error("Invalid JSON in wrapper-translations message")
+            return
+
+        resource_id = payload.get("resource_id")
+        translations = payload.get("translations") or {}
+        if not resource_id or not isinstance(translations, dict) or not translations:
+            return
+
+        indicators = await db.indicators.find(
+            {"resources": resource_id, "deleted": False}
+        ).to_list(length=None)
+        if not indicators:
+            logger.info(f"No indicators linked to resource {resource_id} for translations")
+            return
+
+        for indicator in indicators:
+            indicator_id = indicator["_id"]
+            existing = indicator.get("series_translations") or {}
+            merged = dict(existing)
+            for label, entry in translations.items():
+                if not isinstance(entry, dict):
+                    continue
+                # Don't overwrite admin-edited values (anything already in
+                # the indicator's stored translations stays). New labels and
+                # labels that haven't been touched get the auto-translation.
+                if label in merged:
+                    continue
+                merged[label] = {
+                    "pt": str(entry.get("pt") or "").strip(),
+                    "en": str(entry.get("en") or "").strip(),
+                }
+
+            if merged != existing:
+                await db.indicators.update_one(
+                    {"_id": indicator_id},
+                    {"$set": {"series_translations": merged}},
+                )
+                logger.info(
+                    f"Seeded {len(merged) - len(existing)} translations on indicator {indicator_id}"
+                )

--- a/app/tests/test_series_propagator.py
+++ b/app/tests/test_series_propagator.py
@@ -9,7 +9,7 @@ only the merge / filter / sort / pagination logic — no MongoDB roundtrip.
 
 import unittest
 from unittest.mock import MagicMock, AsyncMock, patch
-from datetime import datetime
+from datetime import datetime, timezone
 from bson.objectid import ObjectId
 
 import services.data_propagator as propagator
@@ -263,6 +263,34 @@ class GetSeriesDataPointsTests(unittest.IsolatedAsyncioTestCase):
         mock_db = self._build_db({})  # no resources have data
         with patch.object(propagator, "db", mock_db):
             series = await propagator.get_series_data_points("507f1f77bcf86cd799439099")
+        self.assertEqual(series, [])
+
+    async def test_timezone_aware_query_dates_dont_crash(self):
+        # Regression: FastAPI parses `?end_date=1993-01-01T00:00:00.000Z` as a
+        # tz-AWARE datetime, while MongoDB returns NAIVE datetimes. Comparing
+        # the two raises TypeError → 500. The lazy-load loop on the chart kept
+        # firing this on every pan, spamming the backend. _to_naive_utc must
+        # normalise both sides before the range filter runs.
+        rid = ObjectId("507f1f77bcf86cd799439010")
+        ts = datetime(2024, 1, 1)  # naive (mongo-style)
+        mock_db = self._build_db({
+            rid: [_segment(ts, [
+                {"x": datetime(2020, 1, 1), "y": 1.0},   # naive
+                {"x": datetime(2021, 1, 1), "y": 2.0},
+            ])]
+        })
+
+        # Aware UTC end_date (what FastAPI hands us from the URL):
+        end_aware = datetime(1993, 1, 1, tzinfo=timezone.utc)
+
+        with patch.object(propagator, "db", mock_db):
+            series = await propagator.get_series_data_points(
+                "507f1f77bcf86cd799439099", end_date=end_aware,
+            )
+
+        # 1993 is before any data → all points filter out → no entries in
+        # the response, NOT a TypeError-driven 500. The point of this test
+        # is "doesn't crash"; the empty result is the natural consequence.
         self.assertEqual(series, [])
 
 

--- a/app/tests/test_series_propagator.py
+++ b/app/tests/test_series_propagator.py
@@ -1,0 +1,270 @@
+"""Tests for the per-resource series read path added in Phase 1.
+
+Run inside the indicator-service container (which has motor / pydantic / bson):
+    docker exec indicator-service python3 -m unittest tests.test_series_propagator -v
+
+These tests mock the `db` object used by services.data_propagator so they exercise
+only the merge / filter / sort / pagination logic — no MongoDB roundtrip.
+"""
+
+import unittest
+from unittest.mock import MagicMock, AsyncMock, patch
+from datetime import datetime
+from bson.objectid import ObjectId
+
+import services.data_propagator as propagator
+
+
+def _segment(ts, points):
+    """Build a fake mongo doc for db.data_segments."""
+    return {"timestamp": ts, "points": points}
+
+
+def _cursor(docs):
+    """Wrap a list as a motor-style cursor (we only use .to_list)."""
+    cur = MagicMock()
+    cur.to_list = AsyncMock(return_value=docs)
+    return cur
+
+
+class MergeResourceSegmentsTests(unittest.IsolatedAsyncioTestCase):
+    """_merge_resource_segments: per-resource dedup keeps the latest segment."""
+
+    async def test_returns_empty_list_when_no_segments(self):
+        mock_db = MagicMock()
+        mock_db.data_segments.find = MagicMock(return_value=_cursor([]))
+
+        with patch.object(propagator, "db", mock_db):
+            points = await propagator._merge_resource_segments(
+                "507f1f77bcf86cd799439011", ObjectId("507f1f77bcf86cd799439012")
+            )
+
+        self.assertEqual(points, [])
+
+    async def test_dedup_picks_latest_segment_per_x(self):
+        x_val = datetime(2020, 1, 1)
+        older = datetime(2020, 1, 1, 10, 0)
+        newer = datetime(2020, 1, 2, 10, 0)
+
+        mock_db = MagicMock()
+        # Two segments overlap on the same x. Newer timestamp must win even
+        # if it appears earlier in the result list (order not guaranteed).
+        mock_db.data_segments.find = MagicMock(return_value=_cursor([
+            _segment(newer, [{"x": x_val, "y": 20.0}]),
+            _segment(older, [{"x": x_val, "y": 10.0}]),
+        ]))
+
+        with patch.object(propagator, "db", mock_db):
+            points = await propagator._merge_resource_segments(
+                "507f1f77bcf86cd799439011", ObjectId("507f1f77bcf86cd799439012")
+            )
+
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0].x, x_val)
+        self.assertEqual(points[0].y, 20.0)
+
+    async def test_same_x_different_series_kept_separate(self):
+        # Multi-column wrappers emit multiple points at the same x — one per
+        # column. The dedup must NOT collapse them.
+        x_val = datetime(2020, 1, 1)
+        ts = datetime(2024, 1, 1)
+        mock_db = MagicMock()
+        mock_db.data_segments.find = MagicMock(return_value=_cursor([
+            _segment(ts, [
+                {"x": x_val, "y": 100.0, "series": "Total"},
+                {"x": x_val, "y": 50.0, "series": "Águas residuais"},
+            ]),
+        ]))
+
+        with patch.object(propagator, "db", mock_db):
+            points = await propagator._merge_resource_segments(
+                "507f1f77bcf86cd799439011", ObjectId("507f1f77bcf86cd799439012")
+            )
+
+        self.assertEqual(len(points), 2)
+        labels = sorted(p.series for p in points)
+        self.assertEqual(labels, ["Total", "Águas residuais"])
+
+    async def test_keeps_distinct_x_values(self):
+        x1 = datetime(2020, 1, 1)
+        x2 = datetime(2021, 1, 1)
+        ts = datetime(2024, 1, 1)
+
+        mock_db = MagicMock()
+        mock_db.data_segments.find = MagicMock(return_value=_cursor([
+            _segment(ts, [
+                {"x": x1, "y": 10.0},
+                {"x": x2, "y": 20.0},
+            ]),
+        ]))
+
+        with patch.object(propagator, "db", mock_db):
+            points = await propagator._merge_resource_segments(
+                "507f1f77bcf86cd799439011", ObjectId("507f1f77bcf86cd799439012")
+            )
+
+        self.assertEqual([p.y for p in points], [10.0, 20.0])  # sorted by x
+
+    async def test_parses_iso_string_x(self):
+        # Wrappers serialise x as ISO strings; merge must accept both.
+        mock_db = MagicMock()
+        mock_db.data_segments.find = MagicMock(return_value=_cursor([
+            _segment(datetime(2024, 1, 1), [{"x": "2020-01-01T00:00:00", "y": 5.0}]),
+        ]))
+
+        with patch.object(propagator, "db", mock_db):
+            points = await propagator._merge_resource_segments(
+                "507f1f77bcf86cd799439011", ObjectId("507f1f77bcf86cd799439012")
+            )
+
+        self.assertEqual(len(points), 1)
+        self.assertEqual(points[0].x, datetime(2020, 1, 1))
+
+
+class GetSeriesDataPointsTests(unittest.IsolatedAsyncioTestCase):
+    """get_series_data_points: one entry per resource, filters & sort applied."""
+
+    def _build_db(self, segments_by_resource):
+        """Build a mock db where distinct() returns the resource IDs and
+        find() filters by resource_id from the in-memory map."""
+        mock_db = MagicMock()
+        mock_db.data_segments.distinct = AsyncMock(
+            return_value=list(segments_by_resource.keys())
+        )
+
+        def find(query):
+            rid = query.get("resource_id")
+            return _cursor(segments_by_resource.get(rid, []))
+
+        mock_db.data_segments.find = MagicMock(side_effect=find)
+        return mock_db
+
+    async def test_one_series_per_resource_legacy(self):
+        # Series-less data (legacy single-stream wrappers) → one entry per
+        # resource with series_label=None.
+        rid_a = ObjectId("507f1f77bcf86cd799439010")
+        rid_b = ObjectId("507f1f77bcf86cd799439011")
+        ts = datetime(2024, 1, 1)
+
+        mock_db = self._build_db({
+            rid_a: [_segment(ts, [{"x": datetime(2020, 1, 1), "y": 1.0}])],
+            rid_b: [_segment(ts, [{"x": datetime(2020, 1, 1), "y": 2.0}])],
+        })
+
+        with patch.object(propagator, "db", mock_db):
+            series = await propagator.get_series_data_points("507f1f77bcf86cd799439099")
+
+        self.assertEqual(len(series), 2)
+        # Each entry has resource_id (stringified), series_label, and points
+        for s in series:
+            self.assertIsNone(s["series_label"])
+        rids = sorted(s["resource_id"] for s in series)
+        self.assertEqual(rids, sorted([str(rid_a), str(rid_b)]))
+        # Values stay separate per resource (we don't merge across resources)
+        ys = {s["resource_id"]: [p["y"] for p in s["points"]] for s in series}
+        self.assertEqual(ys[str(rid_a)], [1.0])
+        self.assertEqual(ys[str(rid_b)], [2.0])
+
+    async def test_one_resource_many_series(self):
+        # The new multi-column path: one resource emits N series labels and
+        # /series should split them into N entries.
+        rid = ObjectId("507f1f77bcf86cd799439010")
+        ts = datetime(2024, 1, 1)
+        mock_db = self._build_db({
+            rid: [_segment(ts, [
+                {"x": datetime(2020, 1, 1), "y": 100.0, "series": "Total"},
+                {"x": datetime(2020, 1, 1), "y": 50.0, "series": "Gestão de águas residuais"},
+                {"x": datetime(2021, 1, 1), "y": 110.0, "series": "Total"},
+                {"x": datetime(2021, 1, 1), "y": 55.0, "series": "Gestão de águas residuais"},
+            ])]
+        })
+
+        with patch.object(propagator, "db", mock_db):
+            series = await propagator.get_series_data_points("507f1f77bcf86cd799439099")
+
+        self.assertEqual(len(series), 2)
+        labels = sorted(s["series_label"] for s in series)
+        self.assertEqual(labels, ["Gestão de águas residuais", "Total"])
+        by_label = {s["series_label"]: s for s in series}
+        # Both series belong to the same resource_id
+        self.assertEqual({s["resource_id"] for s in series}, {str(rid)})
+        # Each series carries only its own data points (not co-mingled)
+        self.assertEqual([p["y"] for p in by_label["Total"]["points"]], [100.0, 110.0])
+        self.assertEqual([p["y"] for p in by_label["Gestão de águas residuais"]["points"]], [50.0, 55.0])
+
+    async def test_iso_serialisation_of_x(self):
+        rid = ObjectId("507f1f77bcf86cd799439010")
+        mock_db = self._build_db({
+            rid: [_segment(datetime(2024, 1, 1), [{"x": datetime(2020, 1, 1), "y": 1.0}])]
+        })
+        with patch.object(propagator, "db", mock_db):
+            series = await propagator.get_series_data_points("507f1f77bcf86cd799439099")
+        self.assertEqual(series[0]["points"][0]["x"], "2020-01-01T00:00:00")
+
+    async def test_date_filter(self):
+        rid = ObjectId("507f1f77bcf86cd799439010")
+        ts = datetime(2024, 1, 1)
+        mock_db = self._build_db({
+            rid: [_segment(ts, [
+                {"x": datetime(2019, 1, 1), "y": 1.0},
+                {"x": datetime(2020, 1, 1), "y": 2.0},
+                {"x": datetime(2021, 1, 1), "y": 3.0},
+            ])]
+        })
+
+        with patch.object(propagator, "db", mock_db):
+            series = await propagator.get_series_data_points(
+                "507f1f77bcf86cd799439099",
+                start_date=datetime(2020, 1, 1),
+                end_date=datetime(2020, 12, 31),
+            )
+
+        ys = [p["y"] for p in series[0]["points"]]
+        self.assertEqual(ys, [2.0])
+
+    async def test_sort_desc(self):
+        rid = ObjectId("507f1f77bcf86cd799439010")
+        mock_db = self._build_db({
+            rid: [_segment(datetime(2024, 1, 1), [
+                {"x": datetime(2019, 1, 1), "y": 1.0},
+                {"x": datetime(2020, 1, 1), "y": 2.0},
+                {"x": datetime(2021, 1, 1), "y": 3.0},
+            ])]
+        })
+
+        with patch.object(propagator, "db", mock_db):
+            series = await propagator.get_series_data_points(
+                "507f1f77bcf86cd799439099", sort="desc"
+            )
+
+        ys = [p["y"] for p in series[0]["points"]]
+        self.assertEqual(ys, [3.0, 2.0, 1.0])
+
+    async def test_limit_and_skip(self):
+        rid = ObjectId("507f1f77bcf86cd799439010")
+        mock_db = self._build_db({
+            rid: [_segment(datetime(2024, 1, 1), [
+                {"x": datetime(2019, 1, 1), "y": 1.0},
+                {"x": datetime(2020, 1, 1), "y": 2.0},
+                {"x": datetime(2021, 1, 1), "y": 3.0},
+                {"x": datetime(2022, 1, 1), "y": 4.0},
+            ])]
+        })
+
+        with patch.object(propagator, "db", mock_db):
+            series = await propagator.get_series_data_points(
+                "507f1f77bcf86cd799439099", skip=1, limit=2
+            )
+
+        ys = [p["y"] for p in series[0]["points"]]
+        self.assertEqual(ys, [2.0, 3.0])
+
+    async def test_empty_indicator_returns_empty_list(self):
+        mock_db = self._build_db({})  # no resources have data
+        with patch.object(propagator, "db", mock_db):
+            series = await propagator.get_series_data_points("507f1f77bcf86cd799439099")
+        self.assertEqual(series, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces support for multi-series indicators, allowing each data resource to provide multiple parallel time series (e.g., from multi-column files). It adds the ability to group, label, and translate these series, exposes a new API endpoint to retrieve them, and ensures series metadata is preserved throughout the data pipeline. Additionally, it introduces mechanisms for managing and translating series labels, including admin overrides and ingestion of translations from external services.

**Multi-Series Data Support and API Enhancements:**

- Added a new endpoint `/indicator/{indicator_id}/series` to retrieve all time series grouped by resource and series label, enabling charting of multiple parallel series from a single resource. (`app/routes/data_routes.py`, `app/services/data_propagator.py`, `app/schemas/data_segment.py`, [[1]](diffhunk://#diff-5eddcd3e9e041cf4ff158d031d8e56f5a49cacdff52f09ee34c0ba42a90c1833R62-R89) [[2]](diffhunk://#diff-636ac7085416f8fab12bcf068bb892eee089887f316b98a23d019b400148e34aR512-R632) [[3]](diffhunk://#diff-1266b8ba78989a980a9ae344e0ac427d631ad891b2129027a5857b47d07484c1R41-R50)
- Updated the data ingestion and merging logic to support deduplication and grouping of points by both `x` value and `series` label, preserving multi-series structure throughout the pipeline. (`app/services/data_ingestor.py`, [[1]](diffhunk://#diff-36e3cea677a067fa5adb09fe853ddd440123892e3392dc372b6040410c11a786L36-R41) [[2]](diffhunk://#diff-36e3cea677a067fa5adb09fe853ddd440123892e3392dc372b6040410c11a786L45-R51) [[3]](diffhunk://#diff-36e3cea677a067fa5adb09fe853ddd440123892e3392dc372b6040410c11a786R60-R78) [[4]](diffhunk://#diff-36e3cea677a067fa5adb09fe853ddd440123892e3392dc372b6040410c11a786L148-R161)

**Series Metadata and Translation Management:**

- Introduced `series`, `series_label`, and `IndicatorSeries` models to annotate and group points by series, and updated schemas to support these fields. (`app/schemas/data_segment.py`, [[1]](diffhunk://#diff-1266b8ba78989a980a9ae344e0ac427d631ad891b2129027a5857b47d07484c1R10-R19) [[2]](diffhunk://#diff-1266b8ba78989a980a9ae344e0ac427d631ad891b2129027a5857b47d07484c1R41-R50)
- Added `hidden_series` and `series_translations` fields to indicators, allowing admins to hide specific series from charts and manage PT/EN translations for each series label. Patch support for these fields is also included. (`app/schemas/indicator.py`, [[1]](diffhunk://#diff-1d31a6594d5de3a0aa97060138fa4e3f836cd21d7b1306b0b6c19a5f40e03311L2-R19) [[2]](diffhunk://#diff-1d31a6594d5de3a0aa97060138fa4e3f836cd21d7b1306b0b6c19a5f40e03311R47-R55) [[3]](diffhunk://#diff-1d31a6594d5de3a0aa97060138fa4e3f836cd21d7b1306b0b6c19a5f40e03311R111-R112)
- Implemented a new consumer (`services.series_translations`) to ingest wrapper-generated series label translations and merge them into indicator metadata, preserving admin overrides. (`app/services/series_translations.py`, [[1]](diffhunk://#diff-dfd2039154697e1ae14b150a93a57cb9e9a3f6ab4ed42616b5e687c17161e40bR1-R70); `app/main.py`, [[2]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR10); `app/config.py`, [[3]](diffhunk://#diff-84f1a9419471e289c6b6e2b0209b329e20df6cef81d1f7f0a193ddc2fc6ad69dR15-R17)

**Charting and Visualization:**

- Extended chart type support to include `stackedColumn` and `stackedBar`, enabling richer visualization options for multi-series data. (`app/schemas/chart_export.py`, [app/schemas/chart_export.pyR12-R13](diffhunk://#diff-9b3ca3c3700df0ca0569517ec7a717c345ff3f96d122c88202ce29de8cc393d7R12-R13))

These changes collectively enable robust handling, labeling, and visualization of multi-series indicator data, with a clear separation of admin-managed and automatically-ingested series metadata.

**References:**
- Multi-series API and ingestion: [[1]](diffhunk://#diff-5eddcd3e9e041cf4ff158d031d8e56f5a49cacdff52f09ee34c0ba42a90c1833R62-R89) [[2]](diffhunk://#diff-636ac7085416f8fab12bcf068bb892eee089887f316b98a23d019b400148e34aR512-R632) [[3]](diffhunk://#diff-1266b8ba78989a980a9ae344e0ac427d631ad891b2129027a5857b47d07484c1R41-R50) [[4]](diffhunk://#diff-36e3cea677a067fa5adb09fe853ddd440123892e3392dc372b6040410c11a786L36-R41) [[5]](diffhunk://#diff-36e3cea677a067fa5adb09fe853ddd440123892e3392dc372b6040410c11a786L45-R51) [[6]](diffhunk://#diff-36e3cea677a067fa5adb09fe853ddd440123892e3392dc372b6040410c11a786R60-R78) [[7]](diffhunk://#diff-36e3cea677a067fa5adb09fe853ddd440123892e3392dc372b6040410c11a786L148-R161)
- Series metadata and translation: [[1]](diffhunk://#diff-1266b8ba78989a980a9ae344e0ac427d631ad891b2129027a5857b47d07484c1R10-R19) [[2]](diffhunk://#diff-1d31a6594d5de3a0aa97060138fa4e3f836cd21d7b1306b0b6c19a5f40e03311L2-R19) [[3]](diffhunk://#diff-1d31a6594d5de3a0aa97060138fa4e3f836cd21d7b1306b0b6c19a5f40e03311R47-R55) [[4]](diffhunk://#diff-1d31a6594d5de3a0aa97060138fa4e3f836cd21d7b1306b0b6c19a5f40e03311R111-R112) [[5]](diffhunk://#diff-dfd2039154697e1ae14b150a93a57cb9e9a3f6ab4ed42616b5e687c17161e40bR1-R70) [[6]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR10) [[7]](diffhunk://#diff-84f1a9419471e289c6b6e2b0209b329e20df6cef81d1f7f0a193ddc2fc6ad69dR15-R17)
- Charting enhancements: [app/schemas/chart_export.pyR12-R13](diffhunk://#diff-9b3ca3c3700df0ca0569517ec7a717c345ff3f96d122c88202ce29de8cc393d7R12-R13)