### PR TITLE
indicators as sources

### DIFF
--- a/app/routes/indicator_routes.py
+++ b/app/routes/indicator_routes.py
@@ -16,7 +16,11 @@ from services.indicator_service import (
     update_indicator,
     delete_indicator,
     add_resource_to_indicator,
+    add_child_indicator,
+    remove_child_indicator,
+    get_child_indicators,
 )
+from pydantic import BaseModel
 from schemas.indicator import (
     IndicatorCreate,
     IndicatorUpdate,
@@ -362,6 +366,63 @@ async def get_resources_route(indicator_id: str):
         return indicator.get("resources", [])
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+class ChildIndicatorRequest(BaseModel):
+    child_id: str
+
+
+@router.post("/{indicator_id}/child-indicators", response_model=Indicator)
+async def add_child_indicator_route(
+    indicator_id: str,
+    body: ChildIndicatorRequest,
+    _=Depends(require_admin),
+):
+    """Include another indicator as a source of this one (composed indicator).
+
+    The child's data tree is appended to this indicator's chart at fetch time;
+    cycles and self-inclusion are rejected.
+    """
+    try:
+        PyObjectId(indicator_id)
+        PyObjectId(body.child_id)
+    except (InvalidId, ValueError):
+        raise HTTPException(status_code=400, detail=INVALID_INDICATOR_ID)
+    try:
+        updated = await add_child_indicator(indicator_id, body.child_id)
+        if not updated:
+            raise HTTPException(status_code=404, detail=NOT_FOUND_MESSAGE)
+        return updated
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.delete("/{indicator_id}/child-indicators/{child_id}", response_model=Indicator)
+async def remove_child_indicator_route(
+    indicator_id: str,
+    child_id: str,
+    _=Depends(require_admin),
+):
+    """Remove a previously-added child indicator."""
+    try:
+        PyObjectId(indicator_id)
+        PyObjectId(child_id)
+    except (InvalidId, ValueError):
+        raise HTTPException(status_code=400, detail=INVALID_INDICATOR_ID)
+    updated = await remove_child_indicator(indicator_id, child_id)
+    if not updated:
+        raise HTTPException(status_code=404, detail=NOT_FOUND_MESSAGE)
+    return updated
+
+
+@router.get("/{indicator_id}/child-indicators", response_model=List[str])
+async def get_child_indicators_route(indicator_id: str):
+    """List the child indicator IDs for this indicator."""
+    try:
+        PyObjectId(indicator_id)
+    except (InvalidId, ValueError):
+        raise HTTPException(status_code=400, detail=INVALID_INDICATOR_ID)
+    return await get_child_indicators(indicator_id)
 
 
 @router.post("/{indicator_id}/export/image", response_class=Response)

--- a/app/schemas/data_segment.py
+++ b/app/schemas/data_segment.py
@@ -44,7 +44,15 @@ class IndicatorSeries(BaseModel):
     """One line on the chart. Identified by (resource_id, series_label):
     a single resource can contribute several series when the source file has
     multiple value columns. series_label is None for legacy single-stream
-    resources (one wrapper → one untagged series)."""
+    resources (one wrapper → one untagged series).
+
+    `source_indicator_*` fields identify which indicator owns the underlying
+    data. They equal the requested indicator for own resources; for composed
+    indicators they identify the child whose resource produced this series.
+    The frontend uses them to label lines when several indicators contribute."""
     resource_id: str
     series_label: Optional[str] = None
     points: List[DataPoint]
+    source_indicator_id: Optional[str] = None
+    source_indicator_name: Optional[str] = None
+    source_indicator_name_en: Optional[str] = None

--- a/app/schemas/indicator.py
+++ b/app/schemas/indicator.py
@@ -116,7 +116,10 @@ class IndicatorPatch(BaseModel):
     default_chart_type: Optional[ChartType] = None
     hidden_series: Optional[List[str]] = None
     series_translations: Optional[Dict[str, SeriesTranslation]] = None
-    child_indicators: Optional[List[str]] = None
+    # NOTE: `child_indicators` deliberately omitted — composed indicators are
+    # managed via POST/DELETE /{id}/child-indicators which run cycle / self-
+    # inclusion / existence checks. Letting PATCH overwrite the list would
+    # bypass those guards.
 
     @model_validator(mode="after")
     def _patch_chart_consistency(self) -> "IndicatorPatch":

--- a/app/schemas/indicator.py
+++ b/app/schemas/indicator.py
@@ -53,6 +53,12 @@ class IndicatorBase(BaseModel):
     # from the data wrapper. Seeded by resource-service after wrapper
     # completion (Gemini sidecar) and editable in the admin wizard.
     series_translations: Dict[str, SeriesTranslation] = Field(default_factory=dict)
+    # Other indicators whose data should appear on this indicator's chart
+    # alongside its own resources. Each child contributes its full series
+    # tree (transitive); cycles are rejected at write time and a depth cap
+    # protects against runtime regressions. Empty for non-composed
+    # indicators.
+    child_indicators: List[str] = Field(default_factory=list)
 
     @field_validator("chart_types")
     @classmethod
@@ -110,6 +116,7 @@ class IndicatorPatch(BaseModel):
     default_chart_type: Optional[ChartType] = None
     hidden_series: Optional[List[str]] = None
     series_translations: Optional[Dict[str, SeriesTranslation]] = None
+    child_indicators: Optional[List[str]] = None
 
     @model_validator(mode="after")
     def _patch_chart_consistency(self) -> "IndicatorPatch":

--- a/app/services/data_propagator.py
+++ b/app/services/data_propagator.py
@@ -7,6 +7,7 @@ from schemas.data_segment import DataPoint
 from dependencies.database import db
 from dependencies.redis import redis_client
 from bson.objectid import ObjectId
+from bson.errors import InvalidId
 from pymongo.errors import ConnectionFailure, ServerSelectionTimeoutError
 from redis.exceptions import ConnectionError as RedisConnectionError, TimeoutError as RedisTimeoutError
 import logging
@@ -667,7 +668,7 @@ async def get_series_data_points(
         visited.add(current_id)
         try:
             current_oid = ObjectId(current_id)
-        except (TypeError, ValueError):
+        except (InvalidId, TypeError, ValueError):
             return
         indicator_doc = await db.indicators.find_one(
             {"_id": current_oid, "deleted": False}

--- a/app/services/data_propagator.py
+++ b/app/services/data_propagator.py
@@ -563,28 +563,25 @@ def _to_naive_utc(dt: Optional[datetime]) -> Optional[datetime]:
     return dt.astimezone(timezone.utc).replace(tzinfo=None)
 
 
-async def get_series_data_points(
-        indicator_id: str,
-        sort: str = "asc",
-        skip: int = 0,
-        limit: int = 1000,
-        start_date: Optional[datetime] = None,
-        end_date: Optional[datetime] = None,
+_COMPOSED_DEPTH_CAP = 8  # belt-and-braces; cycles are also rejected at write time
+
+
+async def _own_series_for_indicator(
+    indicator_id: str,
+    sd: Optional[datetime],
+    ed: Optional[datetime],
+    sort: str,
+    skip: int,
+    limit: int,
+    source_indicator_id: str,
+    source_indicator_name: str,
+    source_indicator_name_en: str,
 ) -> List[Dict[str, Any]]:
-    """One chart line per (resource_id, series_label) pair.
-
-    Returns: [{"resource_id": str, "series_label": str|None,
-               "points": [{"x": iso|float, "y": float}, ...]}, ...]
-
-    A single XLSX with N value columns lives in ONE resource but produces N
-    series here — one entry per column. Resources with no series labels
-    produce a single entry with series_label=None (legacy behaviour).
+    """Build the (resource_id, series_label) → points list for ONE indicator's
+    own data segments. Pulled out of `get_series_data_points` so composed
+    indicators can call it once per ancestor in the tree without re-doing the
+    surrounding orchestration.
     """
-    sd = _to_naive_utc(start_date)
-    ed = _to_naive_utc(end_date)
-    if sd and ed and sd > ed:
-        raise ValueError("start_date must be before end_date")
-
     all_segments = await db.data_segments.find(
         {"indicator_id": ObjectId(indicator_id)},
     ).to_list(None)
@@ -594,6 +591,11 @@ async def get_series_data_points(
         rid = seg.get("resource_id")
         segments_by_resource.setdefault(rid, []).append(seg)
 
+    def _point_sort_key(p):
+        if isinstance(p.x, datetime):
+            return (0, _to_naive_utc(p.x), 0.0)
+        return (1, datetime.min, float(p.x))
+
     series_list: List[Dict[str, Any]] = []
     for rid, segments in segments_by_resource.items():
         points = _merge_segments(segments)
@@ -601,20 +603,14 @@ async def get_series_data_points(
         if sd or ed:
             def _in_range(p):
                 if not isinstance(p.x, datetime):
-                    return True  # numeric x can't be date-filtered; keep
+                    return True
                 x = _to_naive_utc(p.x)
                 return (not sd or x >= sd) and (not ed or x <= ed)
             points = [p for p in points if _in_range(p)]
 
-        # Group by series label inside this resource.
         by_series: Dict[Optional[str], List[DataPoint]] = {}
         for p in points:
             by_series.setdefault(p.series, []).append(p)
-
-        def _point_sort_key(p):
-            if isinstance(p.x, datetime):
-                return (0, _to_naive_utc(p.x), 0.0)
-            return (1, datetime.min, float(p.x))
 
         for series_label, group in by_series.items():
             group.sort(key=_point_sort_key, reverse=(sort == "desc"))
@@ -629,8 +625,69 @@ async def get_series_data_points(
                     }
                     for p in paged
                 ],
+                "source_indicator_id": source_indicator_id,
+                "source_indicator_name": source_indicator_name,
+                "source_indicator_name_en": source_indicator_name_en,
             })
 
+    return series_list
+
+
+async def get_series_data_points(
+        indicator_id: str,
+        sort: str = "asc",
+        skip: int = 0,
+        limit: int = 1000,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
+) -> List[Dict[str, Any]]:
+    """One chart line per (source_indicator_id, resource_id, series_label).
+
+    For a plain indicator this is one entry per (resource_id, series_label),
+    with source_indicator_* identifying the requested indicator.
+
+    For a composed indicator (one with `child_indicators` populated) the
+    response also includes every child's own series, walked transitively
+    with cycle protection — equivalent to inlining each child's chart into
+    the parent.
+    """
+    sd = _to_naive_utc(start_date)
+    ed = _to_naive_utc(end_date)
+    if sd and ed and sd > ed:
+        raise ValueError("start_date must be before end_date")
+
+    series_list: List[Dict[str, Any]] = []
+    visited: set = set()
+
+    async def _walk(current_id: str, depth: int) -> None:
+        if depth > _COMPOSED_DEPTH_CAP:
+            return
+        if current_id in visited:
+            return
+        visited.add(current_id)
+        try:
+            current_oid = ObjectId(current_id)
+        except (TypeError, ValueError):
+            return
+        indicator_doc = await db.indicators.find_one(
+            {"_id": current_oid, "deleted": False}
+        )
+        if not indicator_doc:
+            return
+
+        own = await _own_series_for_indicator(
+            current_id,
+            sd, ed, sort, skip, limit,
+            source_indicator_id=current_id,
+            source_indicator_name=indicator_doc.get("name") or "",
+            source_indicator_name_en=indicator_doc.get("name_en") or "",
+        )
+        series_list.extend(own)
+
+        for child_id in indicator_doc.get("child_indicators", []) or []:
+            await _walk(str(child_id), depth + 1)
+
+    await _walk(str(indicator_id), 0)
     return series_list
 
 

--- a/app/services/indicator_service.py
+++ b/app/services/indicator_service.py
@@ -34,6 +34,11 @@ async def create_indicator(
     domain_id: str, subdomain_name: str, indicator_data: IndicatorCreate
 ) -> Optional[dict]:
     indicator_dict = deserialize(indicator_data.dict())
+    # Composed indicators are managed only through the dedicated
+    # /child-indicators endpoints, which run cycle / self-inclusion / existence
+    # checks. Newly created indicators always start with no children — strip
+    # whatever the caller sent here so they can't sneak in a pre-built tree.
+    indicator_dict.pop("child_indicators", None)
     indicator_dict["_id"] = ObjectId()
     domain = await db.domains.find_one({"_id": ObjectId(domain_id)})
     if not domain:
@@ -350,6 +355,11 @@ async def get_indicator_by_id(indicator_id: str) -> Optional[dict]:
 
 
 async def update_indicator(indicator_id: str, update_data: dict) -> int:
+    # PUT/PATCH must not touch child_indicators — the dedicated endpoints
+    # enforce cycle / self-inclusion / existence checks that this generic
+    # update path doesn't run. Strip the field defensively so neither route
+    # can be used to bypass those guards (incl. constructing a cycle).
+    update_data = {k: v for k, v in update_data.items() if k != "child_indicators"}
     if "domain" in update_data:
         domain_id = update_data["domain"]
         domain = await db.domains.find_one({"_id": ObjectId(domain_id)})
@@ -593,16 +603,26 @@ async def get_child_indicators(indicator_id: str) -> List[str]:
     raw = indicator.get("child_indicators", []) or []
     if not raw:
         return []
-    try:
-        oids = [ObjectId(c) for c in raw]
-    except (InvalidId, TypeError, ValueError):
-        return [str(c) for c in raw]
+    # Validate each id individually — a single malformed entry must not skip
+    # the deletion filter for the rest. Bad entries are dropped (they can't
+    # refer to a real indicator anyway).
+    oids: List[ObjectId] = []
+    valid_str_ids: List[str] = []
+    for c in raw:
+        try:
+            oid = ObjectId(c)
+        except (InvalidId, TypeError, ValueError):
+            continue
+        oids.append(oid)
+        valid_str_ids.append(str(oid))
+    if not oids:
+        return []
     alive = await db.indicators.find(
         {"_id": {"$in": oids}, "deleted": False},
         {"_id": 1},
     ).to_list(None)
     alive_ids = {str(d["_id"]) for d in alive}
-    return [str(c) for c in raw if str(c) in alive_ids]
+    return [s for s in valid_str_ids if s in alive_ids]
 
 
 async def get_indicator_by_resource(resource_id: str) -> Optional[dict]:

--- a/app/services/indicator_service.py
+++ b/app/services/indicator_service.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 from bson.objectid import ObjectId
+from bson.errors import InvalidId
 from pymongo.collation import Collation
 from pymongo.errors import ConnectionFailure, ServerSelectionTimeoutError
 from dependencies.database import db
@@ -504,6 +505,104 @@ async def get_indicator_resources(indicator_id: str) -> List[str]:
         return []
 
     return resources_data
+
+
+async def _is_descendant(ancestor_id: str, candidate_id: str, visited: Optional[set] = None) -> bool:
+    """True iff `ancestor_id` is reachable from `candidate_id` via child_indicators.
+
+    Used to reject cycles when adding `candidate_id` as a child of `ancestor_id`:
+    if the ancestor already lives somewhere in the candidate's subtree, the
+    new edge would close a cycle.
+    """
+    if visited is None:
+        visited = set()
+    if candidate_id in visited:
+        return False
+    visited.add(candidate_id)
+    if candidate_id == ancestor_id:
+        return True
+    try:
+        candidate_oid = ObjectId(candidate_id)
+    except (InvalidId, TypeError, ValueError):
+        return False
+    candidate = await db.indicators.find_one(
+        {"_id": candidate_oid, "deleted": False}
+    )
+    if not candidate:
+        return False
+    for child_id in candidate.get("child_indicators", []) or []:
+        if await _is_descendant(ancestor_id, str(child_id), visited):
+            return True
+    return False
+
+
+async def add_child_indicator(parent_id: str, child_id: str) -> Optional[dict]:
+    """Add `child_id` to `parent_id`'s child_indicators list (idempotent).
+
+    Rejects self-inclusion and cycles. Both indicators must exist and not be
+    deleted. Returns the updated parent indicator on success.
+    """
+    if parent_id == child_id:
+        raise ValueError("An indicator cannot include itself")
+
+    parent = await db.indicators.find_one(
+        {"_id": ObjectId(parent_id), "deleted": False}
+    )
+    if not parent:
+        raise ValueError("Parent indicator not found")
+    child = await db.indicators.find_one(
+        {"_id": ObjectId(child_id), "deleted": False}
+    )
+    if not child:
+        raise ValueError("Child indicator not found")
+
+    # Cycle check: if `parent` is already reachable from `child`, adding the
+    # edge would close a cycle.
+    if await _is_descendant(parent_id, child_id):
+        raise ValueError("Adding this indicator would create a cycle")
+
+    await db.indicators.update_one(
+        {"_id": ObjectId(parent_id), "deleted": False},
+        {"$addToSet": {"child_indicators": child_id}},
+    )
+    return await get_indicator_by_id(parent_id)
+
+
+async def remove_child_indicator(parent_id: str, child_id: str) -> Optional[dict]:
+    """Remove `child_id` from `parent_id`'s child_indicators list."""
+    result = await db.indicators.update_one(
+        {"_id": ObjectId(parent_id), "deleted": False},
+        {"$pull": {"child_indicators": child_id}},
+    )
+    if result.matched_count == 0:
+        return None
+    return await get_indicator_by_id(parent_id)
+
+
+async def get_child_indicators(indicator_id: str) -> List[str]:
+    """Return the child_indicators list for `indicator_id` (or []).
+
+    Filters out IDs of deleted indicators so the response reflects only
+    currently-valid children.
+    """
+    indicator = await db.indicators.find_one(
+        {"_id": ObjectId(indicator_id), "deleted": False}
+    )
+    if not indicator:
+        return []
+    raw = indicator.get("child_indicators", []) or []
+    if not raw:
+        return []
+    try:
+        oids = [ObjectId(c) for c in raw]
+    except (InvalidId, TypeError, ValueError):
+        return [str(c) for c in raw]
+    alive = await db.indicators.find(
+        {"_id": {"$in": oids}, "deleted": False},
+        {"_id": 1},
+    ).to_list(None)
+    alive_ids = {str(d["_id"]) for d in alive}
+    return [str(c) for c in raw if str(c) in alive_ids]
 
 
 async def get_indicator_by_resource(resource_id: str) -> Optional[dict]:

--- a/app/tests/test_indicator_composition.py
+++ b/app/tests/test_indicator_composition.py
@@ -256,6 +256,86 @@ class GetChildIndicatorsTests(unittest.IsolatedAsyncioTestCase):
             ids = await svc.get_child_indicators(A_ID)
         self.assertEqual(ids, [])
 
+    async def test_one_bad_id_does_not_skip_filter_for_others(self):
+        # Regression: previously, if any entry in child_indicators failed
+        # ObjectId() conversion, the function returned the raw list unfiltered
+        # — leaking deleted IDs and the bad entry itself.
+        mock_db, state = _build_db([
+            _doc(A_ID),
+            _doc(B_ID),
+            _doc(C_ID, deleted=True),
+        ])
+        # Inject a malformed entry alongside valid ones.
+        state[ObjectId(A_ID)]["child_indicators"] = [B_ID, "garbage", C_ID]
+        with patch.object(svc, "db", mock_db):
+            ids = await svc.get_child_indicators(A_ID)
+        # Only B remains: the garbage entry is dropped, C is filtered as
+        # deleted.
+        self.assertEqual(ids, [B_ID])
+
+
+class UpdateBypassPreventionTests(unittest.IsolatedAsyncioTestCase):
+    """PUT/PATCH/POST routes go through update_indicator / create_indicator;
+    those generic paths must NOT touch child_indicators (the dedicated
+    endpoints run the cycle checks). Confirm both strip the field defensively.
+    """
+
+    async def test_update_indicator_strips_child_indicators(self):
+        mock_db = MagicMock()
+        captured = {}
+
+        async def update_one(query, update):
+            captured["update"] = update
+            return MagicMock(matched_count=1, modified_count=1)
+
+        mock_db.indicators.update_one = AsyncMock(side_effect=update_one)
+        with patch.object(svc, "db", mock_db):
+            await svc.update_indicator(A_ID, {
+                "name": "renamed",
+                "child_indicators": [B_ID],  # bypass attempt
+            })
+
+        # The $set payload must NOT include child_indicators.
+        set_payload = captured["update"].get("$set", {})
+        self.assertIn("name", set_payload)
+        self.assertNotIn("child_indicators", set_payload)
+
+    async def test_create_indicator_strips_child_indicators(self):
+        from schemas.indicator import IndicatorCreate
+
+        mock_db = MagicMock()
+        inserted_doc = {}
+
+        async def insert_one(doc):
+            inserted_doc.update(doc)
+            return MagicMock(inserted_id=doc["_id"])
+
+        async def find_one_domain(query):
+            return {"_id": query["_id"], "name": "D",
+                    "subdomains": [{"name": "sub"}], "deleted": False}
+
+        async def find_one_indicator(query):
+            return {**inserted_doc, "domain": ObjectId("507f1f77bcf86cd799439999")}
+
+        mock_db.indicators.insert_one = AsyncMock(side_effect=insert_one)
+        mock_db.indicators.find_one = AsyncMock(side_effect=find_one_indicator)
+        mock_db.domains.find_one = AsyncMock(side_effect=find_one_domain)
+
+        # Build a minimal IndicatorCreate. The default chart_types include
+        # 'line', so default_chart_type='line' satisfies the validator.
+        create = IndicatorCreate(
+            name="x", periodicity="annual", favourites=0, governance=False,
+            child_indicators=[B_ID],  # bypass attempt
+        )
+
+        with patch.object(svc, "db", mock_db):
+            await svc.create_indicator(
+                "507f1f77bcf86cd799439999", "sub", create,
+            )
+
+        # The persisted doc must NOT carry child_indicators from the payload.
+        self.assertNotIn("child_indicators", inserted_doc)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/app/tests/test_indicator_composition.py
+++ b/app/tests/test_indicator_composition.py
@@ -1,0 +1,261 @@
+"""Tests for the composed-indicator service helpers (cycle detection,
+add/remove child, get-children-with-deletion-filter).
+
+Run inside the indicator-service container:
+    docker exec indicator-service python3 -m unittest tests.test_indicator_composition -v
+"""
+
+import unittest
+from unittest.mock import MagicMock, AsyncMock, patch
+from bson.objectid import ObjectId
+
+import services.indicator_service as svc
+
+
+# Three valid 24-hex ObjectIds for parent/child relationships.
+A_ID = "507f1f77bcf86cd799439001"
+B_ID = "507f1f77bcf86cd799439002"
+C_ID = "507f1f77bcf86cd799439003"
+D_ID = "507f1f77bcf86cd799439004"
+
+
+def _doc(_id, child_ids=None, deleted=False, name="Ind"):
+    return {
+        "_id": ObjectId(_id) if isinstance(_id, str) else _id,
+        "name": name,
+        "deleted": deleted,
+        "child_indicators": list(child_ids or []),
+        "domain": ObjectId("507f1f77bcf86cd799439999"),
+        "subdomain": "x",
+    }
+
+
+def _build_db(indicators):
+    """Build a mock that resolves db.indicators.find_one and update_one against
+    an in-memory list. update_one returns a result with matched_count=1 when
+    a doc matches the query."""
+    state = {d["_id"]: dict(d) for d in indicators}
+    mock_db = MagicMock()
+
+    async def find_one(query):
+        wanted = query.get("_id")
+        deleted_filter = query.get("deleted")
+        for oid, d in state.items():
+            if oid != wanted:
+                continue
+            if deleted_filter is False and d.get("deleted"):
+                return None
+            return dict(d)
+        return None
+
+    async def update_one(query, update):
+        wanted = query.get("_id")
+        deleted_filter = query.get("deleted")
+        d = state.get(wanted)
+        if not d:
+            return MagicMock(matched_count=0, modified_count=0)
+        if deleted_filter is False and d.get("deleted"):
+            return MagicMock(matched_count=0, modified_count=0)
+        modified = 0
+        if "$addToSet" in update:
+            for k, v in update["$addToSet"].items():
+                arr = d.setdefault(k, [])
+                if v not in arr:
+                    arr.append(v)
+                    modified = 1
+        if "$pull" in update:
+            for k, v in update["$pull"].items():
+                arr = d.get(k, [])
+                new_arr = [x for x in arr if x != v]
+                if new_arr != arr:
+                    d[k] = new_arr
+                    modified = 1
+        if "$set" in update:
+            for k, v in update["$set"].items():
+                d[k] = v
+                modified = 1
+        return MagicMock(matched_count=1, modified_count=modified)
+
+    mock_db.indicators.find_one = AsyncMock(side_effect=find_one)
+    mock_db.indicators.update_one = AsyncMock(side_effect=update_one)
+
+    # find() used by get_child_indicators to filter deleted.
+    def find(query, projection=None):
+        ids = query.get("_id", {}).get("$in", [])
+        deleted_filter = query.get("deleted")
+        result = []
+        for oid in ids:
+            d = state.get(oid)
+            if not d:
+                continue
+            if deleted_filter is False and d.get("deleted"):
+                continue
+            result.append({"_id": d["_id"]})
+        cur = MagicMock()
+        cur.to_list = AsyncMock(return_value=result)
+        return cur
+
+    mock_db.indicators.find = MagicMock(side_effect=find)
+
+    # Need to also stub get_indicator_by_id's domain lookup. Domain doc must
+    # exist for serialize() to work.
+    async def find_one_domain(query):
+        return {"_id": query.get("_id"), "name": "D", "deleted": False, "subdomains": []}
+
+    mock_db.domains.find_one = AsyncMock(side_effect=find_one_domain)
+
+    return mock_db, state
+
+
+class CycleDetectionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_self_is_not_descendant_of_self_via_visited(self):
+        # _is_descendant uses visited so calling with candidate==ancestor must
+        # short-circuit to True (the same-id case is the trivial cycle).
+        mock_db, _ = _build_db([_doc(A_ID)])
+        with patch.object(svc, "db", mock_db):
+            result = await svc._is_descendant(A_ID, A_ID)
+        self.assertTrue(result)
+
+    async def test_unrelated_indicator_is_not_descendant(self):
+        mock_db, _ = _build_db([_doc(A_ID), _doc(B_ID)])
+        with patch.object(svc, "db", mock_db):
+            self.assertFalse(await svc._is_descendant(A_ID, B_ID))
+
+    async def test_transitive_descendant(self):
+        # B → C → A means A is a descendant of B (cycle if B were added under A).
+        mock_db, _ = _build_db([
+            _doc(A_ID),
+            _doc(B_ID, child_ids=[C_ID]),
+            _doc(C_ID, child_ids=[A_ID]),
+        ])
+        with patch.object(svc, "db", mock_db):
+            self.assertTrue(await svc._is_descendant(A_ID, B_ID))
+
+    async def test_invalid_id_returns_false_not_crash(self):
+        mock_db, _ = _build_db([])
+        with patch.object(svc, "db", mock_db):
+            self.assertFalse(await svc._is_descendant(A_ID, "not-an-objectid"))
+
+
+class AddChildIndicatorTests(unittest.IsolatedAsyncioTestCase):
+    async def test_self_inclusion_rejected(self):
+        mock_db, _ = _build_db([_doc(A_ID)])
+        with patch.object(svc, "db", mock_db):
+            with self.assertRaises(ValueError):
+                await svc.add_child_indicator(A_ID, A_ID)
+
+    async def test_missing_parent_rejected(self):
+        mock_db, _ = _build_db([_doc(B_ID)])
+        with patch.object(svc, "db", mock_db):
+            with self.assertRaises(ValueError):
+                await svc.add_child_indicator(A_ID, B_ID)
+
+    async def test_missing_child_rejected(self):
+        mock_db, _ = _build_db([_doc(A_ID)])
+        with patch.object(svc, "db", mock_db):
+            with self.assertRaises(ValueError):
+                await svc.add_child_indicator(A_ID, B_ID)
+
+    async def test_simple_cycle_rejected(self):
+        # B already includes A; adding B as a child of A would close the cycle.
+        mock_db, _ = _build_db([
+            _doc(A_ID),
+            _doc(B_ID, child_ids=[A_ID]),
+        ])
+        with patch.object(svc, "db", mock_db):
+            with self.assertRaises(ValueError) as cm:
+                await svc.add_child_indicator(A_ID, B_ID)
+            self.assertIn("cycle", str(cm.exception).lower())
+
+    async def test_transitive_cycle_rejected(self):
+        # B → C → A. Adding B under A would close A → B → C → A.
+        mock_db, _ = _build_db([
+            _doc(A_ID),
+            _doc(B_ID, child_ids=[C_ID]),
+            _doc(C_ID, child_ids=[A_ID]),
+        ])
+        with patch.object(svc, "db", mock_db):
+            with self.assertRaises(ValueError):
+                await svc.add_child_indicator(A_ID, B_ID)
+
+    async def test_valid_add_persists(self):
+        mock_db, state = _build_db([_doc(A_ID), _doc(B_ID)])
+        with patch.object(svc, "db", mock_db):
+            await svc.add_child_indicator(A_ID, B_ID)
+        a_doc = state[ObjectId(A_ID)]
+        self.assertIn(B_ID, a_doc["child_indicators"])
+
+    async def test_idempotent_add(self):
+        # Adding the same child twice must not duplicate the entry.
+        mock_db, state = _build_db([
+            _doc(A_ID, child_ids=[B_ID]),
+            _doc(B_ID),
+        ])
+        with patch.object(svc, "db", mock_db):
+            await svc.add_child_indicator(A_ID, B_ID)
+        a_doc = state[ObjectId(A_ID)]
+        self.assertEqual(a_doc["child_indicators"].count(B_ID), 1)
+
+    async def test_diamond_allowed(self):
+        # A → B; we now also add A → C where C → D and B → D. Diamond, not a
+        # cycle. Should succeed.
+        mock_db, state = _build_db([
+            _doc(A_ID, child_ids=[B_ID]),
+            _doc(B_ID, child_ids=[D_ID]),
+            _doc(C_ID, child_ids=[D_ID]),
+            _doc(D_ID),
+        ])
+        with patch.object(svc, "db", mock_db):
+            await svc.add_child_indicator(A_ID, C_ID)
+        a_doc = state[ObjectId(A_ID)]
+        self.assertEqual(sorted(a_doc["child_indicators"]), sorted([B_ID, C_ID]))
+
+
+class RemoveChildIndicatorTests(unittest.IsolatedAsyncioTestCase):
+    async def test_remove_present_child(self):
+        mock_db, state = _build_db([
+            _doc(A_ID, child_ids=[B_ID, C_ID]),
+            _doc(B_ID),
+            _doc(C_ID),
+        ])
+        with patch.object(svc, "db", mock_db):
+            await svc.remove_child_indicator(A_ID, B_ID)
+        a_doc = state[ObjectId(A_ID)]
+        self.assertEqual(a_doc["child_indicators"], [C_ID])
+
+    async def test_remove_absent_child_is_noop(self):
+        # Removing a child that isn't there must not error.
+        mock_db, state = _build_db([_doc(A_ID, child_ids=[B_ID]), _doc(B_ID), _doc(C_ID)])
+        with patch.object(svc, "db", mock_db):
+            await svc.remove_child_indicator(A_ID, C_ID)
+        a_doc = state[ObjectId(A_ID)]
+        self.assertEqual(a_doc["child_indicators"], [B_ID])
+
+
+class GetChildIndicatorsTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_only_alive_children(self):
+        # Children that have been (soft-)deleted must be filtered out.
+        mock_db, _ = _build_db([
+            _doc(A_ID, child_ids=[B_ID, C_ID]),
+            _doc(B_ID),
+            _doc(C_ID, deleted=True),
+        ])
+        with patch.object(svc, "db", mock_db):
+            ids = await svc.get_child_indicators(A_ID)
+        self.assertEqual(ids, [B_ID])
+
+    async def test_returns_empty_when_none(self):
+        mock_db, _ = _build_db([_doc(A_ID)])
+        with patch.object(svc, "db", mock_db):
+            ids = await svc.get_child_indicators(A_ID)
+        self.assertEqual(ids, [])
+
+    async def test_missing_parent_returns_empty(self):
+        mock_db, _ = _build_db([])
+        with patch.object(svc, "db", mock_db):
+            ids = await svc.get_child_indicators(A_ID)
+        self.assertEqual(ids, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/tests/test_series_propagator.py
+++ b/app/tests/test_series_propagator.py
@@ -1,10 +1,11 @@
-"""Tests for the per-resource series read path added in Phase 1.
+"""Tests for the per-resource series read path.
 
 Run inside the indicator-service container (which has motor / pydantic / bson):
     docker exec indicator-service python3 -m unittest tests.test_series_propagator -v
 
-These tests mock the `db` object used by services.data_propagator so they exercise
-only the merge / filter / sort / pagination logic — no MongoDB roundtrip.
+These tests mock the `db` object used by services.data_propagator so they
+exercise only the merge / filter / sort / pagination / composition logic —
+no MongoDB roundtrip.
 """
 
 import unittest
@@ -15,9 +16,14 @@ from bson.objectid import ObjectId
 import services.data_propagator as propagator
 
 
-def _segment(ts, points):
+def _segment(ts, points, indicator_id=None, resource_id=None):
     """Build a fake mongo doc for db.data_segments."""
-    return {"timestamp": ts, "points": points}
+    doc = {"timestamp": ts, "points": points}
+    if indicator_id is not None:
+        doc["indicator_id"] = indicator_id
+    if resource_id is not None:
+        doc["resource_id"] = resource_id
+    return doc
 
 
 def _cursor(docs):
@@ -27,271 +33,417 @@ def _cursor(docs):
     return cur
 
 
-class MergeResourceSegmentsTests(unittest.IsolatedAsyncioTestCase):
-    """_merge_resource_segments: per-resource dedup keeps the latest segment."""
+def _indicator_doc(indicator_id, name="Indicator", child_ids=None, name_en=None):
+    """Build a fake indicator doc."""
+    doc = {
+        "_id": ObjectId(indicator_id) if isinstance(indicator_id, str) else indicator_id,
+        "name": name,
+        "name_en": name_en or name,
+        "deleted": False,
+    }
+    if child_ids:
+        doc["child_indicators"] = list(child_ids)
+    return doc
 
-    async def test_returns_empty_list_when_no_segments(self):
-        mock_db = MagicMock()
-        mock_db.data_segments.find = MagicMock(return_value=_cursor([]))
 
-        with patch.object(propagator, "db", mock_db):
-            points = await propagator._merge_resource_segments(
-                "507f1f77bcf86cd799439011", ObjectId("507f1f77bcf86cd799439012")
-            )
+class MergeSegmentsTests(unittest.TestCase):
+    """_merge_segments (sync): per-resource dedup keeps the latest segment."""
 
-        self.assertEqual(points, [])
+    def test_returns_empty_list_when_no_segments(self):
+        self.assertEqual(propagator._merge_segments([]), [])
 
-    async def test_dedup_picks_latest_segment_per_x(self):
+    def test_dedup_picks_latest_segment_per_x(self):
         x_val = datetime(2020, 1, 1)
         older = datetime(2020, 1, 1, 10, 0)
         newer = datetime(2020, 1, 2, 10, 0)
-
-        mock_db = MagicMock()
-        # Two segments overlap on the same x. Newer timestamp must win even
-        # if it appears earlier in the result list (order not guaranteed).
-        mock_db.data_segments.find = MagicMock(return_value=_cursor([
+        # Newer timestamp wins regardless of order in input list.
+        points = propagator._merge_segments([
             _segment(newer, [{"x": x_val, "y": 20.0}]),
             _segment(older, [{"x": x_val, "y": 10.0}]),
-        ]))
-
-        with patch.object(propagator, "db", mock_db):
-            points = await propagator._merge_resource_segments(
-                "507f1f77bcf86cd799439011", ObjectId("507f1f77bcf86cd799439012")
-            )
-
+        ])
         self.assertEqual(len(points), 1)
         self.assertEqual(points[0].x, x_val)
         self.assertEqual(points[0].y, 20.0)
 
-    async def test_same_x_different_series_kept_separate(self):
-        # Multi-column wrappers emit multiple points at the same x — one per
-        # column. The dedup must NOT collapse them.
+    def test_same_x_different_series_kept_separate(self):
         x_val = datetime(2020, 1, 1)
         ts = datetime(2024, 1, 1)
-        mock_db = MagicMock()
-        mock_db.data_segments.find = MagicMock(return_value=_cursor([
+        points = propagator._merge_segments([
             _segment(ts, [
                 {"x": x_val, "y": 100.0, "series": "Total"},
                 {"x": x_val, "y": 50.0, "series": "Águas residuais"},
             ]),
-        ]))
-
-        with patch.object(propagator, "db", mock_db):
-            points = await propagator._merge_resource_segments(
-                "507f1f77bcf86cd799439011", ObjectId("507f1f77bcf86cd799439012")
-            )
-
+        ])
         self.assertEqual(len(points), 2)
-        labels = sorted(p.series for p in points)
-        self.assertEqual(labels, ["Total", "Águas residuais"])
+        self.assertEqual(
+            sorted(p.series for p in points),
+            ["Total", "Águas residuais"],
+        )
 
-    async def test_keeps_distinct_x_values(self):
+    def test_keeps_distinct_x_values(self):
         x1 = datetime(2020, 1, 1)
         x2 = datetime(2021, 1, 1)
         ts = datetime(2024, 1, 1)
+        points = propagator._merge_segments([
+            _segment(ts, [{"x": x1, "y": 10.0}, {"x": x2, "y": 20.0}]),
+        ])
+        self.assertEqual([p.y for p in points], [10.0, 20.0])
 
-        mock_db = MagicMock()
-        mock_db.data_segments.find = MagicMock(return_value=_cursor([
-            _segment(ts, [
-                {"x": x1, "y": 10.0},
-                {"x": x2, "y": 20.0},
-            ]),
-        ]))
-
-        with patch.object(propagator, "db", mock_db):
-            points = await propagator._merge_resource_segments(
-                "507f1f77bcf86cd799439011", ObjectId("507f1f77bcf86cd799439012")
-            )
-
-        self.assertEqual([p.y for p in points], [10.0, 20.0])  # sorted by x
-
-    async def test_parses_iso_string_x(self):
-        # Wrappers serialise x as ISO strings; merge must accept both.
-        mock_db = MagicMock()
-        mock_db.data_segments.find = MagicMock(return_value=_cursor([
+    def test_parses_iso_string_x(self):
+        points = propagator._merge_segments([
             _segment(datetime(2024, 1, 1), [{"x": "2020-01-01T00:00:00", "y": 5.0}]),
-        ]))
-
-        with patch.object(propagator, "db", mock_db):
-            points = await propagator._merge_resource_segments(
-                "507f1f77bcf86cd799439011", ObjectId("507f1f77bcf86cd799439012")
-            )
-
+        ])
         self.assertEqual(len(points), 1)
         self.assertEqual(points[0].x, datetime(2020, 1, 1))
 
 
 class GetSeriesDataPointsTests(unittest.IsolatedAsyncioTestCase):
-    """get_series_data_points: one entry per resource, filters & sort applied."""
+    """get_series_data_points: one entry per (resource, series_label)."""
 
-    def _build_db(self, segments_by_resource):
-        """Build a mock db where distinct() returns the resource IDs and
-        find() filters by resource_id from the in-memory map."""
+    def _build_db(self, segments_by_indicator, indicators=None):
+        """Build a mock db that:
+          - resolves db.indicators.find_one by ObjectId match
+          - resolves db.data_segments.find by indicator_id match
+        `segments_by_indicator` maps indicator_id (str) → list of segment dicts.
+        Each segment dict must include `resource_id` (ObjectId).
+        """
         mock_db = MagicMock()
-        mock_db.data_segments.distinct = AsyncMock(
-            return_value=list(segments_by_resource.keys())
-        )
 
-        def find(query):
-            rid = query.get("resource_id")
-            return _cursor(segments_by_resource.get(rid, []))
+        # Indicators collection: find_one looks up by _id.
+        indicator_docs = list(indicators or [])
+        # Auto-create stub indicator docs for any indicator_id that has segments
+        # but no explicit indicator entry — keeps tests concise.
+        seen_ids = {str(d["_id"]) for d in indicator_docs}
+        for ind_id in segments_by_indicator.keys():
+            if ind_id not in seen_ids:
+                indicator_docs.append(_indicator_doc(ind_id))
 
-        mock_db.data_segments.find = MagicMock(side_effect=find)
+        async def find_one_indicator(query):
+            wanted = query.get("_id")
+            for d in indicator_docs:
+                if d["_id"] == wanted and not d.get("deleted", False):
+                    return d
+            return None
+
+        mock_db.indicators.find_one = AsyncMock(side_effect=find_one_indicator)
+
+        # Data segments collection: find filters by indicator_id.
+        def find_segments(query):
+            ind_oid = query.get("indicator_id")
+            ind_str = str(ind_oid) if ind_oid is not None else None
+            return _cursor(segments_by_indicator.get(ind_str, []))
+
+        mock_db.data_segments.find = MagicMock(side_effect=find_segments)
         return mock_db
 
     async def test_one_series_per_resource_legacy(self):
-        # Series-less data (legacy single-stream wrappers) → one entry per
-        # resource with series_label=None.
+        ind_id = "507f1f77bcf86cd799439099"
         rid_a = ObjectId("507f1f77bcf86cd799439010")
         rid_b = ObjectId("507f1f77bcf86cd799439011")
         ts = datetime(2024, 1, 1)
-
         mock_db = self._build_db({
-            rid_a: [_segment(ts, [{"x": datetime(2020, 1, 1), "y": 1.0}])],
-            rid_b: [_segment(ts, [{"x": datetime(2020, 1, 1), "y": 2.0}])],
+            ind_id: [
+                _segment(ts, [{"x": datetime(2020, 1, 1), "y": 1.0}], resource_id=rid_a),
+                _segment(ts, [{"x": datetime(2020, 1, 1), "y": 2.0}], resource_id=rid_b),
+            ],
         })
 
         with patch.object(propagator, "db", mock_db):
-            series = await propagator.get_series_data_points("507f1f77bcf86cd799439099")
+            series = await propagator.get_series_data_points(ind_id)
 
         self.assertEqual(len(series), 2)
-        # Each entry has resource_id (stringified), series_label, and points
         for s in series:
             self.assertIsNone(s["series_label"])
+            # Source indicator metadata is always populated.
+            self.assertEqual(s["source_indicator_id"], ind_id)
         rids = sorted(s["resource_id"] for s in series)
         self.assertEqual(rids, sorted([str(rid_a), str(rid_b)]))
-        # Values stay separate per resource (we don't merge across resources)
         ys = {s["resource_id"]: [p["y"] for p in s["points"]] for s in series}
         self.assertEqual(ys[str(rid_a)], [1.0])
         self.assertEqual(ys[str(rid_b)], [2.0])
 
     async def test_one_resource_many_series(self):
-        # The new multi-column path: one resource emits N series labels and
-        # /series should split them into N entries.
+        ind_id = "507f1f77bcf86cd799439099"
         rid = ObjectId("507f1f77bcf86cd799439010")
         ts = datetime(2024, 1, 1)
         mock_db = self._build_db({
-            rid: [_segment(ts, [
+            ind_id: [_segment(ts, [
                 {"x": datetime(2020, 1, 1), "y": 100.0, "series": "Total"},
-                {"x": datetime(2020, 1, 1), "y": 50.0, "series": "Gestão de águas residuais"},
+                {"x": datetime(2020, 1, 1), "y": 50.0, "series": "Sub"},
                 {"x": datetime(2021, 1, 1), "y": 110.0, "series": "Total"},
-                {"x": datetime(2021, 1, 1), "y": 55.0, "series": "Gestão de águas residuais"},
-            ])]
+                {"x": datetime(2021, 1, 1), "y": 55.0, "series": "Sub"},
+            ], resource_id=rid)],
         })
 
         with patch.object(propagator, "db", mock_db):
-            series = await propagator.get_series_data_points("507f1f77bcf86cd799439099")
+            series = await propagator.get_series_data_points(ind_id)
 
         self.assertEqual(len(series), 2)
         labels = sorted(s["series_label"] for s in series)
-        self.assertEqual(labels, ["Gestão de águas residuais", "Total"])
-        by_label = {s["series_label"]: s for s in series}
-        # Both series belong to the same resource_id
+        self.assertEqual(labels, ["Sub", "Total"])
         self.assertEqual({s["resource_id"] for s in series}, {str(rid)})
-        # Each series carries only its own data points (not co-mingled)
+        by_label = {s["series_label"]: s for s in series}
         self.assertEqual([p["y"] for p in by_label["Total"]["points"]], [100.0, 110.0])
-        self.assertEqual([p["y"] for p in by_label["Gestão de águas residuais"]["points"]], [50.0, 55.0])
+        self.assertEqual([p["y"] for p in by_label["Sub"]["points"]], [50.0, 55.0])
 
     async def test_iso_serialisation_of_x(self):
+        ind_id = "507f1f77bcf86cd799439099"
         rid = ObjectId("507f1f77bcf86cd799439010")
         mock_db = self._build_db({
-            rid: [_segment(datetime(2024, 1, 1), [{"x": datetime(2020, 1, 1), "y": 1.0}])]
+            ind_id: [_segment(datetime(2024, 1, 1),
+                              [{"x": datetime(2020, 1, 1), "y": 1.0}],
+                              resource_id=rid)],
         })
         with patch.object(propagator, "db", mock_db):
-            series = await propagator.get_series_data_points("507f1f77bcf86cd799439099")
+            series = await propagator.get_series_data_points(ind_id)
         self.assertEqual(series[0]["points"][0]["x"], "2020-01-01T00:00:00")
 
     async def test_date_filter(self):
+        ind_id = "507f1f77bcf86cd799439099"
         rid = ObjectId("507f1f77bcf86cd799439010")
         ts = datetime(2024, 1, 1)
         mock_db = self._build_db({
-            rid: [_segment(ts, [
+            ind_id: [_segment(ts, [
                 {"x": datetime(2019, 1, 1), "y": 1.0},
                 {"x": datetime(2020, 1, 1), "y": 2.0},
                 {"x": datetime(2021, 1, 1), "y": 3.0},
-            ])]
+            ], resource_id=rid)],
         })
-
         with patch.object(propagator, "db", mock_db):
             series = await propagator.get_series_data_points(
-                "507f1f77bcf86cd799439099",
+                ind_id,
                 start_date=datetime(2020, 1, 1),
                 end_date=datetime(2020, 12, 31),
             )
-
         ys = [p["y"] for p in series[0]["points"]]
         self.assertEqual(ys, [2.0])
 
     async def test_sort_desc(self):
+        ind_id = "507f1f77bcf86cd799439099"
         rid = ObjectId("507f1f77bcf86cd799439010")
         mock_db = self._build_db({
-            rid: [_segment(datetime(2024, 1, 1), [
+            ind_id: [_segment(datetime(2024, 1, 1), [
                 {"x": datetime(2019, 1, 1), "y": 1.0},
                 {"x": datetime(2020, 1, 1), "y": 2.0},
                 {"x": datetime(2021, 1, 1), "y": 3.0},
-            ])]
+            ], resource_id=rid)],
         })
-
         with patch.object(propagator, "db", mock_db):
-            series = await propagator.get_series_data_points(
-                "507f1f77bcf86cd799439099", sort="desc"
-            )
-
+            series = await propagator.get_series_data_points(ind_id, sort="desc")
         ys = [p["y"] for p in series[0]["points"]]
         self.assertEqual(ys, [3.0, 2.0, 1.0])
 
     async def test_limit_and_skip(self):
+        ind_id = "507f1f77bcf86cd799439099"
         rid = ObjectId("507f1f77bcf86cd799439010")
         mock_db = self._build_db({
-            rid: [_segment(datetime(2024, 1, 1), [
+            ind_id: [_segment(datetime(2024, 1, 1), [
                 {"x": datetime(2019, 1, 1), "y": 1.0},
                 {"x": datetime(2020, 1, 1), "y": 2.0},
                 {"x": datetime(2021, 1, 1), "y": 3.0},
                 {"x": datetime(2022, 1, 1), "y": 4.0},
-            ])]
+            ], resource_id=rid)],
         })
-
         with patch.object(propagator, "db", mock_db):
-            series = await propagator.get_series_data_points(
-                "507f1f77bcf86cd799439099", skip=1, limit=2
-            )
-
+            series = await propagator.get_series_data_points(ind_id, skip=1, limit=2)
         ys = [p["y"] for p in series[0]["points"]]
         self.assertEqual(ys, [2.0, 3.0])
 
     async def test_empty_indicator_returns_empty_list(self):
-        mock_db = self._build_db({})  # no resources have data
+        ind_id = "507f1f77bcf86cd799439099"
+        mock_db = self._build_db({ind_id: []})
         with patch.object(propagator, "db", mock_db):
-            series = await propagator.get_series_data_points("507f1f77bcf86cd799439099")
+            series = await propagator.get_series_data_points(ind_id)
         self.assertEqual(series, [])
 
     async def test_timezone_aware_query_dates_dont_crash(self):
-        # Regression: FastAPI parses `?end_date=1993-01-01T00:00:00.000Z` as a
-        # tz-AWARE datetime, while MongoDB returns NAIVE datetimes. Comparing
-        # the two raises TypeError → 500. The lazy-load loop on the chart kept
-        # firing this on every pan, spamming the backend. _to_naive_utc must
-        # normalise both sides before the range filter runs.
+        ind_id = "507f1f77bcf86cd799439099"
         rid = ObjectId("507f1f77bcf86cd799439010")
-        ts = datetime(2024, 1, 1)  # naive (mongo-style)
+        ts = datetime(2024, 1, 1)
         mock_db = self._build_db({
-            rid: [_segment(ts, [
-                {"x": datetime(2020, 1, 1), "y": 1.0},   # naive
+            ind_id: [_segment(ts, [
+                {"x": datetime(2020, 1, 1), "y": 1.0},
                 {"x": datetime(2021, 1, 1), "y": 2.0},
-            ])]
+            ], resource_id=rid)],
         })
-
-        # Aware UTC end_date (what FastAPI hands us from the URL):
         end_aware = datetime(1993, 1, 1, tzinfo=timezone.utc)
-
         with patch.object(propagator, "db", mock_db):
-            series = await propagator.get_series_data_points(
-                "507f1f77bcf86cd799439099", end_date=end_aware,
-            )
-
-        # 1993 is before any data → all points filter out → no entries in
-        # the response, NOT a TypeError-driven 500. The point of this test
-        # is "doesn't crash"; the empty result is the natural consequence.
+            series = await propagator.get_series_data_points(ind_id, end_date=end_aware)
         self.assertEqual(series, [])
+
+
+class ComposedIndicatorTests(unittest.IsolatedAsyncioTestCase):
+    """Composition: a parent's /series response includes children's data
+    transitively, every line tagged with its source indicator."""
+
+    def _build_db(self, segments_by_indicator, indicators):
+        mock_db = MagicMock()
+
+        async def find_one_indicator(query):
+            wanted = query.get("_id")
+            for d in indicators:
+                if d["_id"] == wanted and not d.get("deleted", False):
+                    return d
+            return None
+
+        mock_db.indicators.find_one = AsyncMock(side_effect=find_one_indicator)
+
+        def find_segments(query):
+            ind_oid = query.get("indicator_id")
+            ind_str = str(ind_oid) if ind_oid is not None else None
+            return _cursor(segments_by_indicator.get(ind_str, []))
+
+        mock_db.data_segments.find = MagicMock(side_effect=find_segments)
+        return mock_db
+
+    async def test_parent_with_one_child_aggregates_both(self):
+        # A includes B. A has its own data; B has its own data. Chart should
+        # show both lines, each tagged with its source.
+        a_id = "507f1f77bcf86cd799439001"
+        b_id = "507f1f77bcf86cd799439002"
+        rid_a = ObjectId("507f1f77bcf86cd799439101")
+        rid_b = ObjectId("507f1f77bcf86cd799439102")
+        ts = datetime(2024, 1, 1)
+        mock_db = self._build_db(
+            segments_by_indicator={
+                a_id: [_segment(ts, [{"x": datetime(2020, 1, 1), "y": 10.0}], resource_id=rid_a)],
+                b_id: [_segment(ts, [{"x": datetime(2020, 1, 1), "y": 20.0}], resource_id=rid_b)],
+            },
+            indicators=[
+                _indicator_doc(a_id, "Parent A", child_ids=[b_id]),
+                _indicator_doc(b_id, "Child B"),
+            ],
+        )
+        with patch.object(propagator, "db", mock_db):
+            series = await propagator.get_series_data_points(a_id)
+
+        self.assertEqual(len(series), 2)
+        by_source = {s["source_indicator_id"]: s for s in series}
+        self.assertIn(a_id, by_source)
+        self.assertIn(b_id, by_source)
+        self.assertEqual(by_source[a_id]["source_indicator_name"], "Parent A")
+        self.assertEqual(by_source[b_id]["source_indicator_name"], "Child B")
+        self.assertEqual(by_source[a_id]["resource_id"], str(rid_a))
+        self.assertEqual(by_source[b_id]["resource_id"], str(rid_b))
+
+    async def test_transitive_composition(self):
+        # A → B → C. C has data. A's response should include C's series tagged
+        # with C as source — flattening the entire subtree.
+        a_id = "507f1f77bcf86cd799439001"
+        b_id = "507f1f77bcf86cd799439002"
+        c_id = "507f1f77bcf86cd799439003"
+        rid_c = ObjectId("507f1f77bcf86cd799439103")
+        ts = datetime(2024, 1, 1)
+        mock_db = self._build_db(
+            segments_by_indicator={
+                c_id: [_segment(ts, [{"x": datetime(2020, 1, 1), "y": 30.0}], resource_id=rid_c)],
+            },
+            indicators=[
+                _indicator_doc(a_id, "A", child_ids=[b_id]),
+                _indicator_doc(b_id, "B", child_ids=[c_id]),
+                _indicator_doc(c_id, "C"),
+            ],
+        )
+        with patch.object(propagator, "db", mock_db):
+            series = await propagator.get_series_data_points(a_id)
+
+        self.assertEqual(len(series), 1)
+        self.assertEqual(series[0]["source_indicator_id"], c_id)
+        self.assertEqual(series[0]["source_indicator_name"], "C")
+        self.assertEqual(series[0]["points"][0]["y"], 30.0)
+
+    async def test_diamond_no_double_count(self):
+        # A → B → D and A → C → D. D appears in two paths; the visited set
+        # must keep it from being walked twice. Otherwise D's lines would
+        # appear duplicated.
+        a_id = "507f1f77bcf86cd799439001"
+        b_id = "507f1f77bcf86cd799439002"
+        c_id = "507f1f77bcf86cd799439003"
+        d_id = "507f1f77bcf86cd799439004"
+        rid_d = ObjectId("507f1f77bcf86cd799439104")
+        ts = datetime(2024, 1, 1)
+        mock_db = self._build_db(
+            segments_by_indicator={
+                d_id: [_segment(ts, [{"x": datetime(2020, 1, 1), "y": 99.0}], resource_id=rid_d)],
+            },
+            indicators=[
+                _indicator_doc(a_id, "A", child_ids=[b_id, c_id]),
+                _indicator_doc(b_id, "B", child_ids=[d_id]),
+                _indicator_doc(c_id, "C", child_ids=[d_id]),
+                _indicator_doc(d_id, "D"),
+            ],
+        )
+        with patch.object(propagator, "db", mock_db):
+            series = await propagator.get_series_data_points(a_id)
+
+        # D's data must appear exactly once.
+        d_series = [s for s in series if s["source_indicator_id"] == d_id]
+        self.assertEqual(len(d_series), 1)
+
+    async def test_cycle_does_not_loop(self):
+        # If somehow A → B → A escaped the add-time cycle check (e.g. legacy
+        # data), the runtime visited set must still terminate the walk
+        # instead of recursing forever.
+        a_id = "507f1f77bcf86cd799439001"
+        b_id = "507f1f77bcf86cd799439002"
+        rid_a = ObjectId("507f1f77bcf86cd799439101")
+        rid_b = ObjectId("507f1f77bcf86cd799439102")
+        ts = datetime(2024, 1, 1)
+        mock_db = self._build_db(
+            segments_by_indicator={
+                a_id: [_segment(ts, [{"x": datetime(2020, 1, 1), "y": 1.0}], resource_id=rid_a)],
+                b_id: [_segment(ts, [{"x": datetime(2020, 1, 1), "y": 2.0}], resource_id=rid_b)],
+            },
+            indicators=[
+                _indicator_doc(a_id, "A", child_ids=[b_id]),
+                _indicator_doc(b_id, "B", child_ids=[a_id]),  # back-edge
+            ],
+        )
+        with patch.object(propagator, "db", mock_db):
+            series = await propagator.get_series_data_points(a_id)
+
+        # Each indicator contributes once.
+        sources = sorted(s["source_indicator_id"] for s in series)
+        self.assertEqual(sources, sorted([a_id, b_id]))
+
+    async def test_missing_child_silently_skipped(self):
+        # A includes B, but B's doc was deleted. The walk must not crash —
+        # just skip B and return whatever data A has on its own.
+        a_id = "507f1f77bcf86cd799439001"
+        b_id = "507f1f77bcf86cd799439002"
+        rid_a = ObjectId("507f1f77bcf86cd799439101")
+        ts = datetime(2024, 1, 1)
+        mock_db = self._build_db(
+            segments_by_indicator={
+                a_id: [_segment(ts, [{"x": datetime(2020, 1, 1), "y": 1.0}], resource_id=rid_a)],
+            },
+            # Only A's doc exists — B is absent.
+            indicators=[_indicator_doc(a_id, "A", child_ids=[b_id])],
+        )
+        with patch.object(propagator, "db", mock_db):
+            series = await propagator.get_series_data_points(a_id)
+
+        self.assertEqual(len(series), 1)
+        self.assertEqual(series[0]["source_indicator_id"], a_id)
+
+    async def test_plain_indicator_still_tags_source(self):
+        # Even with no children, every line carries source_indicator_*. The
+        # frontend uses the count of distinct source IDs to decide whether to
+        # show the prefix; for a non-composed indicator it sees only one.
+        ind_id = "507f1f77bcf86cd799439099"
+        rid = ObjectId("507f1f77bcf86cd799439010")
+        ts = datetime(2024, 1, 1)
+        mock_db = self._build_db(
+            segments_by_indicator={
+                ind_id: [_segment(ts, [{"x": datetime(2020, 1, 1), "y": 1.0}], resource_id=rid)],
+            },
+            indicators=[_indicator_doc(ind_id, "Solo")],
+        )
+        with patch.object(propagator, "db", mock_db):
+            series = await propagator.get_series_data_points(ind_id)
+        self.assertEqual(len(series), 1)
+        self.assertEqual(series[0]["source_indicator_id"], ind_id)
+        self.assertEqual(series[0]["source_indicator_name"], "Solo")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces support for "composed indicators," allowing one indicator to include other indicators as children. This enables aggregation of data from multiple indicators into a single chart, with safeguards against cycles and self-inclusion. The changes include new API endpoints for managing child indicators, updates to the data schema, and modifications to the data propagation logic to handle composed indicators.

**Composed Indicator Support and API Endpoints:**

* Added new endpoints in `indicator_routes.py` to add, remove, and list child indicators for a given indicator, with cycle and self-inclusion protection. [[1]](diffhunk://#diff-09e14708c72b8cc909139d041bd598716dbd9dfbdd80f1a4afdd882d253b85b3R19-R23) [[2]](diffhunk://#diff-09e14708c72b8cc909139d041bd598716dbd9dfbdd80f1a4afdd882d253b85b3R371-R427)
* Implemented backend service functions in `indicator_service.py` to manage child indicators, including cycle detection, addition, removal, and filtering of deleted children.

**Data Schema Enhancements:**

* Updated the `IndicatorBase` and `IndicatorPatch` models in `schemas/indicator.py` to include a `child_indicators` field, representing the IDs of included child indicators. [[1]](diffhunk://#diff-1d31a6594d5de3a0aa97060138fa4e3f836cd21d7b1306b0b6c19a5f40e03311R56-R61) [[2]](diffhunk://#diff-1d31a6594d5de3a0aa97060138fa4e3f836cd21d7b1306b0b6c19a5f40e03311R119)
* Extended the `IndicatorSeries` model in `schemas/data_segment.py` to include `source_indicator_*` fields, identifying which indicator owns each data series.

**Data Propagation and Aggregation Logic:**

* Refactored `get_series_data_points` in `data_propagator.py` to aggregate data from both the indicator and all its (transitive) children, with a depth cap and cycle protection. Each series now carries its source indicator metadata. [[1]](diffhunk://#diff-636ac7085416f8fab12bcf068bb892eee089887f316b98a23d019b400148e34aL566-L587) [[2]](diffhunk://#diff-636ac7085416f8fab12bcf068bb892eee089887f316b98a23d019b400148e34aR628-R693)
* Added helper function `_own_series_for_indicator` to modularize data fetching for a single indicator, supporting the composed indicator logic.

These changes enable flexible data composition across indicators, improve traceability of data sources, and ensure robust protection against cycles in indicator inclusion.