### PR TITLE
watchdog

### DIFF
--- a/app/dependencies/rabbitmq.py
+++ b/app/dependencies/rabbitmq.py
@@ -18,7 +18,15 @@ class RabbitMQClient:
         self.consumer_tasks: List[asyncio.Task] = []
 
     async def connect(self):
-        self.connection = await aio_pika.connect_robust(self.url)
+        # heartbeat=30 / reconnect_interval=5 make aio_pika notice silent
+        # transport failures within ~60s instead of the default permissive
+        # window — without these, the broker can drop us with no frames and
+        # the consumer loop hangs on a dead iterator for minutes.
+        self.connection = await aio_pika.connect_robust(
+            self.url,
+            heartbeat=30,
+            reconnect_interval=5,
+        )
         self.channel_pool = asyncio.Queue()
 
         for _ in range(self.pool_size):
@@ -26,6 +34,26 @@ class RabbitMQClient:
             await channel.set_qos(prefetch_count=10)
             await self.channel_pool.put(channel)
         logger.info("Connected and initialized channel pool")
+
+    async def health_probe(self, timeout: float = 5.0) -> bool:
+        """Active liveness check — open and close a fresh channel under a deadline.
+
+        Pool channels can go stale across a robust reconnect, so we deliberately
+        bypass the pool. A timeout here means the underlying transport is wedged
+        even if `connection.is_closed` still reads False.
+        """
+        if not self.connection or self.connection.is_closed:
+            return False
+        try:
+            channel = await asyncio.wait_for(self.connection.channel(), timeout=timeout)
+        except (asyncio.TimeoutError, AMQPConnectionError, AMQPChannelError, RuntimeError) as e:
+            logger.warning(f"Health probe: open channel failed: {e}")
+            return False
+        try:
+            await asyncio.wait_for(channel.close(), timeout=timeout)
+        except (asyncio.TimeoutError, AMQPConnectionError, AMQPChannelError, RuntimeError):
+            pass
+        return True
 
     async def close(self):
         for task in self.consumer_tasks:

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,5 @@
+import asyncio
+import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from routes import router as api_router
@@ -10,6 +12,38 @@ import services.resource_cleanup  # noqa
 import services.series_translations  # noqa
 
 logger = logging.getLogger(__name__)
+
+# Watchdog: probe the MQ connection every WATCHDOG_INTERVAL seconds; if it
+# fails FAILURE_THRESHOLD times in a row, exit the process so Docker (restart
+# policy) re-creates the container with fresh connections. Backstop for
+# aio_pika's robust-connection failing silently with a wedged iterator.
+WATCHDOG_INTERVAL = 30
+WATCHDOG_FAILURE_THRESHOLD = 3
+
+
+async def _mq_watchdog():
+    failures = 0
+    while True:
+        try:
+            await asyncio.sleep(WATCHDOG_INTERVAL)
+            ok = await rabbitmq_client.health_probe()
+            if ok:
+                if failures:
+                    logger.info(f"Watchdog: connection recovered after {failures} failure(s)")
+                failures = 0
+                continue
+            failures += 1
+            logger.warning(
+                f"Watchdog: probe failed ({failures}/{WATCHDOG_FAILURE_THRESHOLD})"
+            )
+            if failures >= WATCHDOG_FAILURE_THRESHOLD:
+                logger.error("Watchdog: MQ unrecoverable, exiting for Docker restart")
+                os._exit(1)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.exception(f"Watchdog: unexpected error: {e}")
+
 
 app = FastAPI()
 
@@ -36,9 +70,16 @@ async def lifespan(app: FastAPI):
     await rabbitmq_client.start_consumers()
     logger.info("Started RabbitMQ consumers")
 
+    watchdog_task = asyncio.create_task(_mq_watchdog())
+
     try:
         yield
     finally:
+        watchdog_task.cancel()
+        try:
+            await watchdog_task
+        except asyncio.CancelledError:
+            pass
         if rabbitmq_client:
             await rabbitmq_client.close()
             logger.info("Closed RabbitMQ connection")

--- a/app/routes/health.py
+++ b/app/routes/health.py
@@ -1,8 +1,12 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
+from dependencies.rabbitmq import rabbitmq_client
 
 router = APIRouter()
 
 
 @router.get("/")
-def read_root():
-    return {"message": "Hello from indicator service!"}
+async def health_check():
+    mq_ok = await rabbitmq_client.health_probe()
+    if mq_ok:
+        return {"status": "ok", "rabbitmq": True}
+    raise HTTPException(status_code=503, detail={"rabbitmq": False})


### PR DESCRIPTION
This pull request introduces a robust health-check and watchdog system for the RabbitMQ connection to improve reliability and observability. It adds an active liveness probe to detect silent connection failures, exposes this via the health endpoint, and implements a watchdog that restarts the service if the connection remains unhealthy. Additionally, it tunes the RabbitMQ connection parameters for faster detection of transport failures.

**RabbitMQ connection health improvements:**

* Added a `health_probe` method to the `rabbitmq_client` in `app/dependencies/rabbitmq.py` that actively checks liveness by opening and closing a fresh channel with a timeout, ensuring the connection is truly healthy and not just superficially open.
* Tuned `aio_pika.connect_robust` parameters (`heartbeat=30`, `reconnect_interval=5`) to detect silent transport failures within ~60 seconds instead of several minutes.

**Service reliability enhancements:**

* Implemented a watchdog task in `app/main.py` that periodically invokes the RabbitMQ health probe; if the probe fails a configurable number of times consecutively, the process exits to trigger a Docker container restart, ensuring recovery from wedged connections. [[1]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR16-R47) [[2]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR73-R82)

**Health endpoint improvements:**

* Updated the health endpoint in `app/routes/health.py` to use the new RabbitMQ health probe, returning a 503 error if the connection is not healthy.

**Miscellaneous:**

* Added necessary imports and minor setup in `app/main.py` to support the new features.