### PR TITLE
fix dying indicators

### DIFF
--- a/app/routes/indicator_routes.py
+++ b/app/routes/indicator_routes.py
@@ -80,6 +80,10 @@ async def get_indicators_route(
         None, description="Filter by governance indicator: true/false"
     ),
     include_hidden: bool = Query(False, description="Include hidden indicators"),
+    status_filter: str = Query(
+        None,
+        description="Filter by lifecycle status: draft, published, all. Default hides drafts.",
+    ),
 ):
     indicators = await get_all_indicators(
         skip=skip,
@@ -88,6 +92,7 @@ async def get_indicators_route(
         sort_order=sort_order,
         governance_filter=governance_filter,
         include_hidden=include_hidden,
+        status_filter=status_filter,
     )
     return indicators
 
@@ -107,6 +112,9 @@ async def search_indicators_route(
     domain_filter: str = Query(None, description="Filter by domain ID"),
     subdomain_filter: str = Query(None, description="Filter by subdomain name"),
     include_hidden: bool = Query(False, description="Include hidden indicators"),
+    status_filter: str = Query(
+        None, description="Filter by lifecycle status: draft, published, all."
+    ),
 ):
     indicators = await search_indicators(
         query=q,
@@ -118,6 +126,7 @@ async def search_indicators_route(
         domain_filter=domain_filter,
         subdomain_filter=subdomain_filter,
         include_hidden=include_hidden,
+        status_filter=status_filter,
     )
     return indicators
 
@@ -125,9 +134,14 @@ async def search_indicators_route(
 @router.get("/count", response_model=int)
 async def get_indicators_count_route(
     include_hidden: bool = Query(False, description="Include hidden indicators"),
+    status_filter: str = Query(
+        None, description="Filter by lifecycle status: draft, published, all."
+    ),
 ):
     """Get total count of indicators"""
-    count = await get_indicators_count(include_hidden=include_hidden)
+    count = await get_indicators_count(
+        include_hidden=include_hidden, status_filter=status_filter
+    )
     return count
 
 
@@ -150,6 +164,9 @@ async def get_indicators_count_by_domain_route(
         None, description="Filter by governance indicator: true/false"
     ),
     include_hidden: bool = Query(False, description="Include hidden indicators"),
+    status_filter: str = Query(
+        None, description="Filter by lifecycle status: draft, published, all."
+    ),
 ):
     """Get total count of indicators for a specific domain"""
     try:
@@ -158,7 +175,10 @@ async def get_indicators_count_by_domain_route(
         raise HTTPException(status_code=400, detail=INVALID_DOMAIN_ID)
     try:
         count = await get_indicators_count_by_domain(
-            domain_id, governance_filter=governance_filter, include_hidden=include_hidden
+            domain_id,
+            governance_filter=governance_filter,
+            include_hidden=include_hidden,
+            status_filter=status_filter,
         )
         return count
     except ValueError as e:
@@ -178,6 +198,9 @@ async def get_indicators_by_domain_route(
         None, description="Filter by governance indicator: true/false"
     ),
     include_hidden: bool = Query(False, description="Include hidden indicators"),
+    status_filter: str = Query(
+        None, description="Filter by lifecycle status: draft, published, all."
+    ),
 ):
     try:
         PyObjectId(domain_id)
@@ -192,6 +215,7 @@ async def get_indicators_by_domain_route(
             sort_order=sort_order,
             governance_filter=governance_filter,
             include_hidden=include_hidden,
+            status_filter=status_filter,
         )
         return indicators
     except ValueError as e:
@@ -206,6 +230,9 @@ async def get_indicators_count_by_subdomain_route(
         None, description="Filter by governance indicator: true/false"
     ),
     include_hidden: bool = Query(False, description="Include hidden indicators"),
+    status_filter: str = Query(
+        None, description="Filter by lifecycle status: draft, published, all."
+    ),
 ):
     """Get total count of indicators for a specific subdomain"""
     try:
@@ -214,7 +241,11 @@ async def get_indicators_count_by_subdomain_route(
         raise HTTPException(status_code=400, detail=INVALID_DOMAIN_ID)
     try:
         count = await get_indicators_count_by_subdomain(
-            domain_id, subdomain_name, governance_filter=governance_filter, include_hidden=include_hidden
+            domain_id,
+            subdomain_name,
+            governance_filter=governance_filter,
+            include_hidden=include_hidden,
+            status_filter=status_filter,
         )
         return count
     except ValueError as e:
@@ -238,6 +269,9 @@ async def get_indicators_by_subdomain_route(
         None, description="Filter by governance indicator: true/false"
     ),
     include_hidden: bool = Query(False, description="Include hidden indicators"),
+    status_filter: str = Query(
+        None, description="Filter by lifecycle status: draft, published, all."
+    ),
 ):
     try:
         PyObjectId(domain_id)
@@ -253,6 +287,7 @@ async def get_indicators_by_subdomain_route(
             sort_order=sort_order,
             governance_filter=governance_filter,
             include_hidden=include_hidden,
+            status_filter=status_filter,
         )
         return indicators
     except ValueError as e:

--- a/app/schemas/indicator.py
+++ b/app/schemas/indicator.py
@@ -98,13 +98,23 @@ DEFAULT_CHART_TYPES: List[ChartType] = [
 DEFAULT_CHART_TYPE: ChartType = ChartType.line
 
 
+IndicatorStatus = Literal["draft", "published"]
+
+
 class IndicatorBase(BaseModel):
     name: str
     name_en: Optional[str] = ""
-    periodicity: str
+    # Drafts can be saved with only name + area + dimension, so periodicity
+    # and favourites need defaults — the strict required-field validation
+    # used to reject "Guardar rascunho" submissions outright.
+    periodicity: Optional[str] = ""
     periodicity_en: Optional[str] = ""
-    favourites: int
-    governance: bool
+    favourites: int = 0
+    governance: bool = False
+    # Lifecycle flag. Drafts are hidden from public listings and from the
+    # admin's default view; the admin opts into seeing them via the
+    # "Rascunhos" pill (status_filter=draft on the API).
+    status: IndicatorStatus = "published"
     description: Optional[str] = None
     description_en: Optional[str] = ""
     font: Optional[str] = None
@@ -179,6 +189,8 @@ class IndicatorPatch(BaseModel):
     favourites: Optional[int] = None
     governance: Optional[bool] = None
     hidden: Optional[bool] = None
+    # Promote draft → published (or demote, though the UI doesn't do that).
+    status: Optional[IndicatorStatus] = None
     description: Optional[str] = None
     description_en: Optional[str] = None
     font: Optional[str] = None

--- a/app/services/indicator_service.py
+++ b/app/services/indicator_service.py
@@ -31,6 +31,32 @@ logger = logging.getLogger(__name__)
 PT_COLLATION = Collation(locale="pt", strength=1)
 
 
+def _apply_status_filter(filter_criteria: dict, status_filter: Optional[str]) -> dict:
+    """Mutate `filter_criteria` in place with the draft/published clause.
+
+    - status_filter="draft"      → only drafts
+    - status_filter="published"  → only published
+    - status_filter="all"        → both (admin "Rascunhos" toggle off-state
+                                    still wants drafts in admin lists if
+                                    explicitly asked; not used by default)
+    - None / anything else       → published-or-legacy (status missing/null
+                                    is treated as published so existing docs
+                                    keep showing up)
+
+    Legacy indicators created before the `status` field existed don't have it
+    at all; treat those as published so this rollout is non-breaking.
+    """
+    if status_filter == "draft":
+        filter_criteria["status"] = "draft"
+    elif status_filter == "all":
+        pass
+    else:
+        # Default: hide drafts. Match docs where status is either "published"
+        # or missing entirely (legacy data).
+        filter_criteria["status"] = {"$ne": "draft"}
+    return filter_criteria
+
+
 async def create_indicator(
     domain_id: str, subdomain_name: str, indicator_data: IndicatorCreate
 ) -> Optional[dict]:
@@ -71,6 +97,7 @@ async def get_all_indicators(
     sort_order: str = "asc",
     governance_filter: bool = None,
     include_hidden: bool = False,
+    status_filter: Optional[str] = None,
 ) -> List[dict]:
     # Define sort order
     sort_direction = 1 if sort_order.lower() == "asc" else -1
@@ -100,6 +127,7 @@ async def get_all_indicators(
             filter_criteria["$nor"] = hidden_dims
     if governance_filter is not None:
         filter_criteria["governance"] = governance_filter
+    _apply_status_filter(filter_criteria, status_filter)
 
     indicators = (
         await db.indicators.find(filter_criteria)
@@ -112,7 +140,9 @@ async def get_all_indicators(
     return [serialize(indicator) for indicator in indicators]
 
 
-async def get_indicators_count(include_hidden: bool = False) -> int:
+async def get_indicators_count(
+    include_hidden: bool = False, status_filter: Optional[str] = None
+) -> int:
     """Get total count of non-deleted indicators"""
     filter_criteria = {"deleted": False}
     if not include_hidden:
@@ -123,12 +153,16 @@ async def get_indicators_count(include_hidden: bool = False) -> int:
         hidden_dims = await get_hidden_dimension_keys()
         if hidden_dims:
             filter_criteria["$nor"] = hidden_dims
+    _apply_status_filter(filter_criteria, status_filter)
     count = await db.indicators.count_documents(filter_criteria)
     return count
 
 
 async def get_indicators_count_by_domain(
-    domain_id: str, governance_filter: bool = None, include_hidden: bool = False
+    domain_id: str,
+    governance_filter: bool = None,
+    include_hidden: bool = False,
+    status_filter: Optional[str] = None,
 ) -> int:
     """Get total count of indicators for a specific domain"""
     if not include_hidden and await is_domain_hidden(domain_id):
@@ -142,13 +176,18 @@ async def get_indicators_count_by_domain(
             filter_criteria["subdomain"] = {"$nin": hidden_subs_here}
     if governance_filter is not None:
         filter_criteria["governance"] = governance_filter
+    _apply_status_filter(filter_criteria, status_filter)
 
     count = await db.indicators.count_documents(filter_criteria)
     return count
 
 
 async def get_indicators_count_by_subdomain(
-    domain_id: str, subdomain_name: str, governance_filter: bool = None, include_hidden: bool = False
+    domain_id: str,
+    subdomain_name: str,
+    governance_filter: bool = None,
+    include_hidden: bool = False,
+    status_filter: Optional[str] = None,
 ) -> int:
     """Get total count of indicators for a specific subdomain"""
     if not include_hidden and await is_subdomain_hidden(domain_id, subdomain_name):
@@ -162,6 +201,7 @@ async def get_indicators_count_by_subdomain(
         filter_criteria["hidden"] = {"$ne": True}
     if governance_filter is not None:
         filter_criteria["governance"] = governance_filter
+    _apply_status_filter(filter_criteria, status_filter)
 
     count = await db.indicators.count_documents(filter_criteria)
     return count
@@ -177,6 +217,7 @@ async def search_indicators(
     domain_filter: str = None,
     subdomain_filter: str = None,
     include_hidden: bool = False,
+    status_filter: Optional[str] = None,
 ) -> List[dict]:
     """Search indicators by name (accent-folded, AND across words), with relevance scoring that also rewards description/subdomain matches.
 
@@ -219,6 +260,13 @@ async def search_indicators(
 
         if subdomain_filter is not None:
             search_criteria["$and"].append({"subdomain": subdomain_filter})
+
+        # Draft/published clause — pulled in as another AND term so it sits
+        # alongside the other filters instead of mutating the top-level dict.
+        status_clause: dict = {}
+        _apply_status_filter(status_clause, status_filter)
+        if status_clause:
+            search_criteria["$and"].append(status_clause)
 
         indicators = await db.indicators.find(search_criteria).to_list(None)
 
@@ -405,6 +453,7 @@ async def get_indicators_by_domain(
     sort_order: str = "asc",
     governance_filter: bool = None,
     include_hidden: bool = False,
+    status_filter: Optional[str] = None,
 ) -> List[dict]:
     # Define sort order
     sort_direction = 1 if sort_order.lower() == "asc" else -1
@@ -434,6 +483,7 @@ async def get_indicators_by_domain(
             filter_criteria["subdomain"] = {"$nin": hidden_subs_here}
     if governance_filter is not None:
         filter_criteria["governance"] = governance_filter
+    _apply_status_filter(filter_criteria, status_filter)
 
     indicators = (
         await db.indicators.find(filter_criteria)
@@ -455,6 +505,7 @@ async def get_indicators_by_subdomain(
     sort_order: str = "asc",
     governance_filter: bool = None,
     include_hidden: bool = False,
+    status_filter: Optional[str] = None,
 ) -> List[dict]:
     if not include_hidden and await is_subdomain_hidden(domain_id, subdomain_name):
         return []
@@ -485,6 +536,7 @@ async def get_indicators_by_subdomain(
         filter_criteria["hidden"] = {"$ne": True}
     if governance_filter is not None:
         filter_criteria["governance"] = governance_filter
+    _apply_status_filter(filter_criteria, status_filter)
 
     indicators = (
         await db.indicators.find(filter_criteria)


### PR DESCRIPTION
This pull request introduces a lifecycle status ("draft" vs "published") for indicators, allowing the API and data model to distinguish between draft and published indicators. It adds the ability to filter, count, and retrieve indicators based on their status, and ensures legacy indicators (without a status field) are treated as published for backward compatibility.

**API and Filtering Enhancements:**

* Added a `status_filter` query parameter (draft/published/all) to all relevant indicator API endpoints, allowing clients to filter results by lifecycle status. [[1]](diffhunk://#diff-09e14708c72b8cc909139d041bd598716dbd9dfbdd80f1a4afdd882d253b85b3R83-R86) [[2]](diffhunk://#diff-09e14708c72b8cc909139d041bd598716dbd9dfbdd80f1a4afdd882d253b85b3R115-R117) [[3]](diffhunk://#diff-09e14708c72b8cc909139d041bd598716dbd9dfbdd80f1a4afdd882d253b85b3R167-R169) [[4]](diffhunk://#diff-09e14708c72b8cc909139d041bd598716dbd9dfbdd80f1a4afdd882d253b85b3R201-R203) [[5]](diffhunk://#diff-09e14708c72b8cc909139d041bd598716dbd9dfbdd80f1a4afdd882d253b85b3R233-R235) [[6]](diffhunk://#diff-09e14708c72b8cc909139d041bd598716dbd9dfbdd80f1a4afdd882d253b85b3R272-R274)
* Updated the indicator service methods (e.g., `get_all_indicators`, `get_indicators_count`, `search_indicators`, etc.) to accept and apply the `status_filter` parameter, ensuring queries respect the requested status and treat legacy indicators as published by default. [[1]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR100) [[2]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR130) [[3]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cL115-R145) [[4]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR156-R165) [[5]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR179-R190) [[6]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR204) [[7]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR220) [[8]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR264-R270) [[9]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR456) [[10]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR486) [[11]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR508) [[12]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR539)
* Introduced a helper function `_apply_status_filter` to encapsulate the logic for applying the status filter to MongoDB queries, including handling legacy documents.

**Data Model Changes:**

* Added a `status` field to the `IndicatorBase` schema, defaulting to "published", and made `periodicity`, `favourites`, and `governance` fields optional or defaulted to support saving drafts with minimal data.
* Updated the `IndicatorPatch` schema to allow updating the `status` field, enabling promotion or demotion between draft and published.