### PR TITLE
orphans gone

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,13 @@ class Settings(BaseSettings):
     RESOURCE_DELETED_QUEUE: str = Field(
         default="resource_deleted", env="RESOURCE_DELETED_QUEUE"
     )
+    # Published when an indicator is deleted so resource-service can stop the
+    # wrappers of any resources that are now orphaned (no other indicator uses
+    # them) — otherwise their continuous API wrappers run forever and clog the
+    # ingest pipeline.
+    INDICATOR_DELETED_QUEUE: str = Field(
+        default="indicator_deleted", env="INDICATOR_DELETED_QUEUE"
+    )
     WRAPPER_TRANSLATIONS_QUEUE: str = Field(
         default="wrapper_translations", env="WRAPPER_TRANSLATIONS_QUEUE"
     )

--- a/app/services/data_ingestor.py
+++ b/app/services/data_ingestor.py
@@ -150,21 +150,28 @@ async def process_message(message: aio_pika.abc.AbstractIncomingMessage):
             return
 
         try:
-            # Find indicator by resource. When the user adds multiple sources
-            # at once, wrappers can publish data before the frontend finishes
-            # linking every resource to the indicator. Without a retry the
-            # racing messages are silently dropped and the indicator chart
-            # ends up empty. Poll briefly so the late-linked sources still
-            # land instead of being lost.
+            # Find indicator by resource. The resource→indicator link can lag
+            # the data by a moment (the wizard links a resource just after its
+            # wrapper starts producing), so a not-yet-linked resource gets ONE
+            # deferred retry. Crucially this must NOT block the single consumer
+            # for long: the old version slept 6×5s = 30s per message, so a few
+            # *permanently* orphaned resources (deleted/unlinked indicators
+            # whose continuous wrappers kept publishing) clogged the whole
+            # pipeline and starved legitimate data. Now: a brief grace, then
+            # requeue once for a late link, then discard — bounded and mostly
+            # non-blocking.
             indicator = await get_indicator_by_resource(resource_id)
-            attempts = 0
-            while not indicator and attempts < 6:
-                await asyncio.sleep(5)
+            if not indicator and not message.redelivered:
+                await asyncio.sleep(2)  # brief grace for the link to settle
                 indicator = await get_indicator_by_resource(resource_id)
-                attempts += 1
+                if not indicator:
+                    # Defer instead of blocking — the consumer keeps serving
+                    # other messages; this one gets one more shot when redelivered.
+                    await message.nack(requeue=True)
+                    return
             if not indicator:
                 logger.warning(
-                        f"No indicator found for resource {resource_id} after {attempts} retries - discarding message")
+                        f"No indicator found for resource {resource_id} - discarding message")
                 await message.ack()  # Acknowledge and discard
                 return
 

--- a/app/services/indicator_service.py
+++ b/app/services/indicator_service.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+import json
 import logging
 import secrets
 import unicodedata
@@ -7,6 +8,8 @@ from bson.errors import InvalidId
 from pymongo.collation import Collation
 from pymongo.errors import ConnectionFailure, ServerSelectionTimeoutError
 from dependencies.database import db
+from dependencies.rabbitmq import rabbitmq_client
+from config import settings
 from schemas.indicator import IndicatorCreate, IndicatorDelete, CompositionCreate
 from services.domain_service import (
     get_hidden_domain_ids,
@@ -437,12 +440,50 @@ async def update_indicator(indicator_id: str, update_data: dict) -> int:
 
 
 async def delete_indicator(indicator_id: str) -> Optional[IndicatorDelete]:
+    indicator = await db.indicators.find_one({"_id": ObjectId(indicator_id)})
     result = await db.indicators.update_one(
         {"_id": ObjectId(indicator_id)}, {"$set": {"deleted": True}}
     )
     if result.modified_count > 0:
+        # Stop the wrappers of resources that are now orphaned — i.e. not used
+        # by any OTHER non-deleted indicator. Otherwise their continuous API
+        # wrappers keep running forever, publishing data that has no home and
+        # clogging the ingest pipeline. resource-service does the actual stop.
+        await _signal_orphaned_resource_cleanup(indicator_id, indicator)
         return IndicatorDelete(id=indicator_id, deleted=True)
     return None
+
+
+async def _signal_orphaned_resource_cleanup(indicator_id: str, indicator: Optional[dict]) -> None:
+    """Tell resource-service to stop the wrappers of resources left orphaned by
+    this indicator's deletion. Best-effort: never fail the delete over it."""
+    try:
+        resource_ids = (indicator or {}).get("resources", []) or []
+        orphaned = []
+        for rid in resource_ids:
+            still_used = await db.indicators.count_documents({
+                "resources": rid,
+                "deleted": False,
+                "_id": {"$ne": ObjectId(indicator_id)},
+            })
+            if still_used == 0:
+                orphaned.append(rid)
+        if not orphaned:
+            return
+        await rabbitmq_client.publish(
+            settings.INDICATOR_DELETED_QUEUE,
+            json.dumps({"indicator_id": indicator_id, "resource_ids": orphaned}),
+        )
+        logger.info(
+            f"Requested wrapper stop for {len(orphaned)} orphaned resource(s) "
+            f"after deleting indicator {indicator_id}"
+        )
+    except Exception as e:  # noqa: BLE001 — cleanup is best-effort
+        logger.error(
+            f"Failed to signal orphaned-resource cleanup for indicator "
+            f"{indicator_id}: {e}",
+            exc_info=True,
+        )
 
 
 async def get_indicators_by_domain(


### PR DESCRIPTION
This pull request introduces improvements to the handling of orphaned resources when an indicator is deleted, optimizes the data ingestion retry logic to prevent pipeline blockage, and adds supporting infrastructure for inter-service communication. The main goals are to ensure that unused resource wrappers are stopped promptly, and to make the data ingestion process more robust and efficient.

**Resource cleanup and inter-service communication:**

* Added a new `INDICATOR_DELETED_QUEUE` setting to `app/config.py` to publish events when an indicator is deleted, enabling the resource service to stop wrappers for resources no longer in use.
* Implemented `_signal_orphaned_resource_cleanup` in `indicator_service.py` to identify and signal for cleanup of resources orphaned by indicator deletion, publishing the relevant resource IDs to the new queue.

**Data ingestion reliability and efficiency:**

* Refactored the retry logic in `process_message` in `data_ingestor.py` to give each message a single brief retry if a resource→indicator link is missing, preventing the consumer from being blocked by permanently orphaned resources and ensuring the pipeline remains responsive.

**Dependency and import updates:**

* Added necessary imports for `json`, `rabbitmq_client`, and `settings` in `indicator_service.py` to support the new messaging functionality. [[1]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR2) [[2]](diffhunk://#diff-dbea5c38a1cddb1da966da640a38946f8f6a2e39a36b4c5bad4aeeb8a873de7cR11-R12)